### PR TITLE
Fix compilation on certain systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ atbuild
 *~
 *.orig
 .clangd
+/.cache

--- a/src/include/pcap_wrapper.h
+++ b/src/include/pcap_wrapper.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <array>
 #include <functional>
 #include <memory>
 #include <pcap/pcap.h>


### PR DESCRIPTION
The project compiled fine on my Orange Pi (Armbian) but trying to compile on my laptop (Fedora, x86) resulted in the following error:
```
../src/include/pcap_wrapper.h:38:38: error: field ‘errbuf’ has incomplete type ‘std::array<char, 256>’
   38 |   std::array<char, PCAP_ERRBUF_SIZE> errbuf{{0}};
```

I didn't bother looking into the differences between the two systems to pinpoint the exact cause, I just included the necessary header in the file.

Also added a directory my compiler was generating to the .gitignore.