### PR TITLE
Optional static linking for libsleep-proxy

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,8 @@
+option(
+  'libsleep_proxy_linking',
+  type: 'combo',
+  choices: ['dynamic', 'static'],
+  value: 'dynamic',
+  description: 'Whether to dynamically or statically link libsleep-proxy'
+)
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,11 +20,21 @@ pcap_dep = meson.get_compiler('cpp').find_library('pcap')
 thread_dep = dependency('threads')
 
 sleep_proxy_include = include_directories('include')
-sleep_proxy_lib = shared_library(
-        'sleep-proxy',
-         sleep_proxy_sources,
-         dependencies : [pcap_dep, thread_dep],
-         include_directories : sleep_proxy_include)
+
+if get_option('libsleep_proxy_linking') == 'dynamic'
+        sleep_proxy_lib = shared_library(
+                'sleep-proxy',
+                 sleep_proxy_sources,
+                 dependencies : [pcap_dep, thread_dep],
+                 include_directories : sleep_proxy_include)
+else
+        sleep_proxy_lib = static_library(
+                'sleep-proxy',
+                sleep_proxy_sources,
+                dependencies : [pcap_dep, thread_dep],
+                include_directories : sleep_proxy_include)
+endif
+
 sleep_proxy_dep = declare_dependency(
         link_with : sleep_proxy_lib,
         include_directories : sleep_proxy_include,


### PR DESCRIPTION
My use case (which I believe to be a common one) is to just use `watchHost` and ignore the other executables. Under this scenario, it makes sense to statically link libsleep-proxy so that installing the software is slightly easier.

This PR adds a new option, `libsleep_proxy_linking`, which can be used to switch between dynamic and static linking of libsleep-proxy. The steps to create a statically linked executable are as follows:
```
mkdir build
cd build
meson ..
meson configure -Dlibsleep_proxy_linking=static
ninja
```

If `libsleep_proxy_linking` is not explicitly set, it will default to `dynamic` and the build process will retain its current behaviour of creating dynamically linked executables.