### PR TITLE
Add option for switching between available wol methods

### DIFF
--- a/config/watchHost.conf
+++ b/config/watchHost.conf
@@ -24,6 +24,11 @@
 ## after waking the server how often pinging shall be tried before unsuccessfully
 ## giving up
 #ping_tries 5
+## method used when sending the wakeonlan magic packet
+## can be one of:
+##   ethernet - broadcasts a magic packet directly over ethernet (default)
+##   udp - broadcasts a UDP magic packet on port 9
+#wol_method ethernet
 
 ## second box
 #host
@@ -34,4 +39,5 @@
 #mac FF:EE:DD:CC:BB:AA
 #interface br-lan
 #ping_tries 1
+#wol_method udp
 

--- a/src/include/args.h
+++ b/src/include/args.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ip_address.h"
+#include "wol.h"
 #include <netinet/ether.h>
 #include <ostream>
 #include <string>
@@ -39,13 +40,15 @@ struct Args {
   const ether_addr mac;
   const std::string hostname;
   const unsigned int ping_tries;
+  const Wol_method wol_method;
   const bool &syslog;
 
   Args();
 
   Args(const std::string &interface_, const std::vector<std::string> &addresss_,
        const std::vector<std::string> &ports_, const std::string &mac_,
-       const std::string &hostname_, const std::string &ping_tries_);
+       const std::string &hostname_, const std::string &ping_tries_,
+       const std::string &wol_method_);
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)

--- a/src/include/wol.h
+++ b/src/include/wol.h
@@ -20,10 +20,19 @@
 #include <string>
 #include <vector>
 
+enum class Wol_method { ethernet, udp };
+
 /**
  * create the payload for a UDP wol packet to be broadcast in to the network
  */
 std::vector<uint8_t> create_wol_payload(const ether_addr &mac);
+
+/**
+ * validates and converts human readable wol method into its respective enum
+ * value
+ */
+Wol_method parse_wol_method(const std::string &wol_method);
+std::ostream &operator<<(std::ostream &out, const Wol_method &wol_method);
 
 /**
  * Send a WOL UDP packet to the given mac

--- a/src/sleep-proxy/libsleep_proxy.cpp
+++ b/src/sleep-proxy/libsleep_proxy.cpp
@@ -261,7 +261,12 @@ Emulate_host_status emulate_host(const Args &args) {
   // release_locks()
   locks.clear();
   // wake the sleeping server
-  wol_ethernet(args.interface, args.mac);
+  if (args.wol_method == Wol_method::udp) {
+    wol_udp(args.mac);
+  } else {
+    wol_ethernet(args.interface, args.mac);
+  }
+
   // wait until server responds and release ICMP rules
   log_string(LOG_INFO,
              "ping: " + std::get<3>(status_data_source_destination).pure());

--- a/src/sleep-proxy/wol.cpp
+++ b/src/sleep-proxy/wol.cpp
@@ -36,6 +36,33 @@ std::vector<uint8_t> create_wol_payload(const ether_addr &mac) {
   return magic_bytes;
 }
 
+Wol_method parse_wol_method(const std::string &readable_wol_method) {
+  if (readable_wol_method == "ethernet") {
+    return Wol_method::ethernet;
+  }
+
+  if (readable_wol_method == "udp") {
+    return Wol_method::udp;
+  }
+
+  throw std::invalid_argument("invalid wol method: " + readable_wol_method);
+}
+
+std::ostream &operator<<(std::ostream &out, const Wol_method &wol_method) {
+  switch (wol_method) {
+  case Wol_method::ethernet:
+    out << "ethernet";
+    break;
+  case Wol_method::udp:
+    out << "udp";
+    break;
+  default:
+    throw std::runtime_error("invalid wol method");
+    break;
+  }
+  return out;
+}
+
 void wol_udp(const ether_addr &mac) {
   log_string(LOG_INFO, "waking (udp) " + binary_to_mac(mac));
   const std::vector<uint8_t> binary_data = create_wol_payload(mac);

--- a/tests/watchhosts
+++ b/tests/watchhosts
@@ -7,6 +7,7 @@ port 23456
 mac 01:12:34:45:67:89
 interface lo
 ping_tries 5
+wol_method ethernet
 
 host
 name test2
@@ -16,6 +17,7 @@ port 22
 mac FF:EE:DD:CC:BB:AA
 interface lo
 ping_tries 1
+wol_method udp
 
 host
 

--- a/tests/wol_test.cpp
+++ b/tests/wol_test.cpp
@@ -28,6 +28,10 @@
 class Wol_test : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(Wol_test);
   CPPUNIT_TEST(test_create_wol_payload);
+  CPPUNIT_TEST(test_parse_wol_method);
+  CPPUNIT_TEST(test_parse_invalid_wol_method);
+  CPPUNIT_TEST(test_ostream_operator);
+  CPPUNIT_TEST(test_ostream_operator_with_invalid_wol_method);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -57,6 +61,30 @@ public:
     wol_packet = create_wol_payload(mac_to_binary("88:99:aA:bB:cc:dd"));
     // NOLINTNEXTLINE
     check_wol_payload(wol_packet, 8, 14);
+  }
+
+  static void test_parse_wol_method() {
+    auto ethernet_method = parse_wol_method("ethernet");
+    CPPUNIT_ASSERT_EQUAL(Wol_method::ethernet, ethernet_method);
+    auto udp_method = parse_wol_method("udp");
+    CPPUNIT_ASSERT_EQUAL(Wol_method::udp, udp_method);
+  }
+
+  static void test_parse_invalid_wol_method() {
+    CPPUNIT_ASSERT_THROW(parse_wol_method("unknown"), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(parse_wol_method(""), std::invalid_argument);
+  }
+
+  static void test_ostream_operator() {
+    std::stringstream stream;
+    stream << Wol_method::ethernet << ',' << Wol_method::udp;
+    CPPUNIT_ASSERT_EQUAL(std::string{"ethernet,udp"}, stream.str());
+  }
+
+  static void test_ostream_operator_with_invalid_wol_method() {
+    std::stringstream stream;
+    auto invalid_method = static_cast<Wol_method>(-1);
+    CPPUNIT_ASSERT_THROW(stream << invalid_method, std::runtime_error);
   }
 };
 


### PR DESCRIPTION
I could not get this software to wake up one of my machines. Investigation led to the discovery that this specific machine will not wake up to the default raw socket broadcast but responds fine to a UDP magic packet.

This PR adds a new configuration argument `wol_method` to allow users to take advantage of the already implemented `wol_udp` function instead of always using `wol_ethernet`. `wol_ethernet` will be used as the default method if the option is left unspecified.