### PR TITLE
Adjust build path in clang tidy script

### DIFF
--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-find * -name "*.h" -or -name "*.cpp" | xargs clang-tidy -p .
+find * -name "*.h" -or -name "*.cpp" | xargs clang-tidy -p build
 
 exit 0


### PR DESCRIPTION
Small adjustment to the provided `clang-tidy.sh` script to make it search for `compile_commands.json` inside of the build directory instead of the project root.