### PR TITLE
Include cstdint where fixed width types are used

### DIFF
--- a/src/include/args.h
+++ b/src/include/args.h
@@ -18,6 +18,7 @@
 
 #include "ip_address.h"
 #include "wol.h"
+#include <cstdint>
 #include <netinet/ether.h>
 #include <ostream>
 #include <string>

--- a/src/include/container_utils.h
+++ b/src/include/container_utils.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <iterator>
 #include <sstream>
 #include <stdexcept>

--- a/src/include/ethernet.h
+++ b/src/include/ethernet.h
@@ -20,6 +20,7 @@
 #include "to_string.h"
 #include <arpa/inet.h>
 #include <array>
+#include <cstdint>
 #include <memory>
 #include <netinet/ether.h>
 #include <ostream>

--- a/src/include/int_utils.h
+++ b/src/include/int_utils.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "to_string.h"
+#include <cstdint>
 #include <limits>
 #include <stdexcept>
 #include <string>

--- a/src/include/ip.h
+++ b/src/include/ip.h
@@ -20,6 +20,7 @@
 #include "ip_address.h"
 #include "log.h"
 #include <arpa/inet.h>
+#include <cstdint>
 #include <memory>
 #include <net/ethernet.h>
 #include <stdexcept>

--- a/src/include/ip_address.h
+++ b/src/include/ip_address.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <arpa/inet.h>
+#include <cstdint>
 #include <ostream>
 #include <string>
 

--- a/src/include/libsleep_proxy.h
+++ b/src/include/libsleep_proxy.h
@@ -18,6 +18,7 @@
 
 #include "args.h"
 #include "ip_address.h"
+#include <cstdint>
 #include <exception>
 #include <string>
 

--- a/src/include/socket.h
+++ b/src/include/socket.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cerrno>
+#include <cstdint>
 #include <cstring>
 #include <linux/if.h>
 #include <netinet/ether.h>

--- a/src/include/spawn_process.h
+++ b/src/include/spawn_process.h
@@ -18,6 +18,7 @@
 
 #include "file_descriptor.h"
 #include "to_string.h"
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <type_traits>

--- a/src/include/wol.h
+++ b/src/include/wol.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <netinet/ether.h>
 #include <string>
 #include <vector>

--- a/src/include/wol_watcher.h
+++ b/src/include/wol_watcher.h
@@ -16,6 +16,7 @@
 
 #include "pcap_wrapper.h"
 #include "scope_guard.h"
+#include <cstdint>
 #include <netinet/ether.h>
 #include <string>
 #include <thread>

--- a/tests/packet_test_utils/include/packet_test_utils.h
+++ b/tests/packet_test_utils/include/packet_test_utils.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cppunit/extensions/HelperMacros.h>
+#include <cstdint>
 #include <ethernet.h>
 #include <file_descriptor.h>
 #include <ip.h>


### PR DESCRIPTION
The code relied on transitive cstdint includes from system headers which is not present anymore with GCC-13.