### PR TITLE
Refactor Args struct and argument parsing

### DIFF
--- a/src/emulateHost.cpp
+++ b/src/emulateHost.cpp
@@ -21,18 +21,18 @@
 
 int main(int argc, char *argv[]) {
   std::span<char *> const args{argv, static_cast<size_t>(argc)};
-  std::vector<Args> argss(read_commandline(argc, argv));
-  if (argss.empty()) {
+  Args argss(read_commandline(argc, argv));
+  if (argss.host_args.empty()) {
     log_string(LOG_ERR, "no configuration given");
     return EXIT_FAILURE;
   }
-  if (argss.at(0).syslog) {
+  if (argss.syslog) {
     setup_log(args[0], 0, LOG_DAEMON);
   }
-  log_string(LOG_INFO, argss.at(0));
+  log_string(LOG_INFO, argss.host_args.at(0));
   setup_signals();
   try {
-    emulate_host(argss.at(0));
+    emulate_host(argss.host_args.at(0));
   } catch (std::exception &e) {
     log(LOG_ERR, "what: %s", e.what());
   } catch (...) {

--- a/src/emulateHost.cpp
+++ b/src/emulateHost.cpp
@@ -16,6 +16,7 @@
 
 #include "libsleep_proxy.h"
 #include "log.h"
+#include <cstdlib>
 #include <span>
 
 int main(int argc, char *argv[]) {
@@ -23,7 +24,7 @@ int main(int argc, char *argv[]) {
   std::vector<Args> argss(read_commandline(argc, argv));
   if (argss.empty()) {
     log_string(LOG_ERR, "no configuration given");
-    return 1;
+    return EXIT_FAILURE;
   }
   if (argss.at(0).syslog) {
     setup_log(args[0], 0, LOG_DAEMON);
@@ -37,5 +38,5 @@ int main(int argc, char *argv[]) {
   } catch (...) {
     log_string(LOG_ERR, "Something went terribly wrong");
   }
-  return 0;
+  return EXIT_FAILURE;
 }

--- a/src/emulateHost.cpp
+++ b/src/emulateHost.cpp
@@ -21,7 +21,7 @@
 
 int main(int argc, char *argv[]) {
   std::span<char *> const args{argv, static_cast<size_t>(argc)};
-  Args argss(read_commandline(argc, argv));
+  Args argss(read_commandline(args));
   if (argss.host_args.empty()) {
     log_string(LOG_ERR, "no configuration given");
     return EXIT_FAILURE;

--- a/src/emulateHost.cpp
+++ b/src/emulateHost.cpp
@@ -16,16 +16,17 @@
 
 #include "libsleep_proxy.h"
 #include "log.h"
+#include <span>
 
 int main(int argc, char *argv[]) {
+  std::span<char *> const args{argv, static_cast<size_t>(argc)};
   std::vector<Args> argss(read_commandline(argc, argv));
   if (argss.empty()) {
     log_string(LOG_ERR, "no configuration given");
     return 1;
   }
   if (argss.at(0).syslog) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    setup_log(argv[0], 0, LOG_DAEMON);
+    setup_log(args[0], 0, LOG_DAEMON);
   }
   log_string(LOG_INFO, argss.at(0));
   setup_signals();

--- a/src/include/args.h
+++ b/src/include/args.h
@@ -31,30 +31,29 @@ void print_help();
  */
 struct Host_args {
   /** the interface to use */
-  const std::string interface;
+  std::string interface {};
   /** addresses to listen on */
-  const std::vector<IP_address> address;
+  std::vector<IP_address> address{};
   /** ports to listen on */
-  const std::vector<uint16_t> ports;
+  std::vector<uint16_t> ports{};
   /** mac of the target machine to wake up */
-  const ether_addr mac;
-  const std::string hostname;
-  const unsigned int ping_tries;
-  const Wol_method wol_method;
-
-  Host_args();
-
-  Host_args(const std::string &interface_,
-            const std::vector<std::string> &addresss_,
-            const std::vector<std::string> &ports_, const std::string &mac_,
-            const std::string &hostname_, const std::string &ping_tries_,
-            const std::string &wol_method_);
+  ether_addr mac{};
+  std::string hostname{};
+  unsigned int ping_tries{};
+  Wol_method wol_method{};
 };
 
 struct Args {
   const std::vector<Host_args> host_args;
   const bool syslog;
 };
+
+Host_args parse_host_args(const std::string &interface_,
+                          const std::vector<std::string> &addresss_,
+                          const std::vector<std::string> &ports_,
+                          const std::string &mac_, const std::string &hostname_,
+                          const std::string &ping_tries_,
+                          const std::string &wol_method_);
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
 Args read_commandline(int argc, char *const argv[]);

--- a/src/include/args.h
+++ b/src/include/args.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <netinet/ether.h>
 #include <ostream>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -55,8 +56,7 @@ Host_args parse_host_args(const std::string &interface_,
                           const std::string &ping_tries_,
                           const std::string &wol_method_);
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
-Args read_commandline(int argc, char *const argv[]);
+Args read_commandline(std::span<char *> const &args);
 
 /**
  * write args into out

--- a/src/include/args.h
+++ b/src/include/args.h
@@ -42,6 +42,19 @@ struct Host_args {
   std::string hostname{};
   unsigned int ping_tries{};
   Wol_method wol_method{};
+
+  Host_args() = default;
+
+  Host_args(std::string interface_, std::vector<IP_address> address_,
+            std::vector<uint16_t> ports_, ether_addr mac_,
+            std::string hostname_, unsigned int ping_tries_,
+            Wol_method wol_method_)
+      : interface {
+    std::move(interface_)
+  }, address{std::move(address_)}, ports{std::move(ports_)}, mac{mac_},
+      hostname{std::move(hostname_)}, ping_tries{ping_tries_},
+      wol_method{wol_method_} {
+  }
 };
 
 struct Args {

--- a/src/include/args.h
+++ b/src/include/args.h
@@ -24,13 +24,12 @@
 #include <string>
 #include <vector>
 
-void reset();
 void print_help();
 
 /**
  * Parses and checks the input of the command line arguments
  */
-struct Args {
+struct Host_args {
   /** the interface to use */
   const std::string interface;
   /** addresses to listen on */
@@ -42,18 +41,28 @@ struct Args {
   const std::string hostname;
   const unsigned int ping_tries;
   const Wol_method wol_method;
-  const bool &syslog;
 
-  Args();
+  Host_args();
 
-  Args(const std::string &interface_, const std::vector<std::string> &addresss_,
-       const std::vector<std::string> &ports_, const std::string &mac_,
-       const std::string &hostname_, const std::string &ping_tries_,
-       const std::string &wol_method_);
+  Host_args(const std::string &interface_,
+            const std::vector<std::string> &addresss_,
+            const std::vector<std::string> &ports_, const std::string &mac_,
+            const std::string &hostname_, const std::string &ping_tries_,
+            const std::string &wol_method_);
+};
+
+struct Args {
+  const std::vector<Host_args> host_args;
+  const bool syslog;
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
-std::vector<Args> read_commandline(int argc, char *const argv[]);
+Args read_commandline(int argc, char *const argv[]);
+
+/**
+ * write args into out
+ */
+std::ostream &operator<<(std::ostream &out, const Host_args &args);
 
 /**
  * write args into out

--- a/src/include/ip_utils.h
+++ b/src/include/ip_utils.h
@@ -28,12 +28,12 @@ std::string validate_iface(std::string const &iface);
 
 template <typename Container, typename Func>
 auto parse_items(Container &&items, Func &&parser) -> std::vector<
-    typename std::result_of<decltype(parser)(const std::string &)>::type> {
+    typename std::invoke_result_t<decltype(parser), const std::string &>> {
   static_assert(std::is_same<typename std::decay<Container>::type::value_type,
                              std::string>::value,
                 "container has to carry std::string");
   std::vector<
-      typename std::result_of<decltype(parser)(const std::string &)>::type>
+      typename std::invoke_result_t<decltype(parser), const std::string &>>
       ret_val(items.size());
   std::transform(std::begin(items), std::end(items), std::begin(ret_val),
                  std::forward<Func>(parser));

--- a/src/include/libsleep_proxy.h
+++ b/src/include/libsleep_proxy.h
@@ -44,4 +44,4 @@ enum class Emulate_host_status {
   undefined_error
 };
 
-Emulate_host_status emulate_host(const Args &args);
+Emulate_host_status emulate_host(const Host_args &args);

--- a/src/sleep-proxy/args.cpp
+++ b/src/sleep-proxy/args.cpp
@@ -138,8 +138,7 @@ Host_args parse_host_args(const std::string &interface_,
   return hargs;
 }
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
-Args read_commandline(const int argc, char *const argv[]) {
+Args read_commandline(std::span<char *> const &args) {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
   static const option long_options[] = {
       {"help", no_argument, nullptr, 'h'},
@@ -153,9 +152,11 @@ Args read_commandline(const int argc, char *const argv[]) {
   bool to_syslog = false;
 
   // read cmd line arguments and checks them
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-  while ((c = getopt_long(argc, argv, "hc:s", long_options, &option_index)) !=
-         -1) {
+  while (
+      (c = getopt_long(
+           static_cast<int>(args.size()), args.data(), "hc:s",
+           // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+           long_options, &option_index)) != -1) {
     switch (c) {
     case 'h':
       print_help();

--- a/src/sleep-proxy/libsleep_proxy.cpp
+++ b/src/sleep-proxy/libsleep_proxy.cpp
@@ -73,7 +73,7 @@ void set_signal(const int signum, const struct sigaction &sa) {
 /**
  * Adds from args the IPs to the machine and setups the firewall
  */
-std::vector<Scope_guard> setup_firewall_and_ips(const Args &args) {
+std::vector<Scope_guard> setup_firewall_and_ips(const Host_args &args) {
   std::vector<Scope_guard> guards;
   for (auto const &ip : args.address) {
     // setup firewall first, some services might respond
@@ -96,7 +96,7 @@ std::vector<Scope_guard> setup_firewall_and_ips(const Args &args) {
  */
 std::tuple<Pcap_wrapper::Loop_end_reason, std::vector<uint8_t>, IP_address,
            IP_address>
-wait_and_listen(const Args &args) {
+wait_and_listen(const Host_args &args) {
   Pcap_wrapper pc("any");
 
   // guards to handle signals and address duplication
@@ -230,7 +230,7 @@ bool ping_and_wait(const std::string &iface, const IP_address &ip,
  * Puts everything together. Sets up firewall and IPs. Waits for an incoming
  * SYN packet and wakes the sleeping host via WOL
  */
-Emulate_host_status emulate_host(const Args &args) {
+Emulate_host_status emulate_host(const Host_args &args) {
   // setup firewall rules and add IPs to the interface
   std::vector<Scope_guard> locks(setup_firewall_and_ips(args));
   // wait until upon an incoming connection

--- a/src/watchHost.cpp
+++ b/src/watchHost.cpp
@@ -19,7 +19,9 @@
 #include "log.h"
 #include <algorithm>
 #include <csignal>
+#include <cstdlib>
 #include <future>
+#include <span>
 #include <thread>
 #include <type_traits>
 
@@ -69,11 +71,11 @@ int main(int argc, char *argv[]) {
     auto argss = read_commandline(argc, argv);
     if (argss.empty()) {
       log_string(LOG_ERR, "no configuration given");
-      return 1;
+      return EXIT_FAILURE;
     }
     if (argss.at(0).syslog) {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-      setup_log(argv[0], 0, LOG_DAEMON);
+      std::span<char *> const args{argv, static_cast<size_t>(argc)};
+      setup_log(args[0], 0, LOG_DAEMON);
     }
     std::vector<std::thread> threads;
     threads.reserve(argss.size());
@@ -88,5 +90,5 @@ int main(int argc, char *argv[]) {
   } catch (std::exception const &e) {
     log(LOG_ERR, "something wrong: %s\n", e.what());
   }
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/src/watchHost.cpp
+++ b/src/watchHost.cpp
@@ -37,7 +37,7 @@ bool ping_ips(const std::string &iface, const Container &ips) {
                      [](std::future<bool> &f) { return f.get(); });
 }
 
-void thread_main(const Args &args) {
+void thread_main(const Host_args &args) {
   bool loop = true;
   while (!is_signaled() && loop) {
     log_string(LOG_INFO, "ping " + args.hostname);
@@ -69,18 +69,18 @@ int main(int argc, char *argv[]) {
   try {
     setup_signals();
     auto argss = read_commandline(argc, argv);
-    if (argss.empty()) {
+    if (argss.host_args.empty()) {
       log_string(LOG_ERR, "no configuration given");
       return EXIT_FAILURE;
     }
-    if (argss.at(0).syslog) {
+    if (argss.syslog) {
       std::span<char *> const args{argv, static_cast<size_t>(argc)};
       setup_log(args[0], 0, LOG_DAEMON);
     }
     std::vector<std::thread> threads;
-    threads.reserve(argss.size());
-    for (auto &args : argss) {
-      threads.emplace_back(thread_main, std::move(args));
+    threads.reserve(argss.host_args.size());
+    for (auto const &args : argss.host_args) {
+      threads.emplace_back(thread_main, args);
     }
     std::for_each(std::begin(threads), std::end(threads), [](std::thread &t) {
       if (t.joinable()) {

--- a/src/watchHost.cpp
+++ b/src/watchHost.cpp
@@ -68,19 +68,19 @@ void thread_main(const Host_args &args) {
 int main(int argc, char *argv[]) {
   try {
     setup_signals();
-    auto argss = read_commandline(argc, argv);
+    std::span<char *> const args{argv, static_cast<size_t>(argc)};
+    auto argss = read_commandline(args);
     if (argss.host_args.empty()) {
       log_string(LOG_ERR, "no configuration given");
       return EXIT_FAILURE;
     }
     if (argss.syslog) {
-      std::span<char *> const args{argv, static_cast<size_t>(argc)};
       setup_log(args[0], 0, LOG_DAEMON);
     }
     std::vector<std::thread> threads;
     threads.reserve(argss.host_args.size());
-    for (auto const &args : argss.host_args) {
-      threads.emplace_back(thread_main, args);
+    for (auto const &hargs : argss.host_args) {
+      threads.emplace_back(thread_main, hargs);
     }
     std::for_each(std::begin(threads), std::end(threads), [](std::thread &t) {
       if (t.joinable()) {

--- a/tests/args_test.cpp
+++ b/tests/args_test.cpp
@@ -62,8 +62,8 @@ parse_ports(std::vector<std::string> const &ports) {
   // reset getopt() to the start
   optind = 0;
   auto vs = to_vector_strings(params);
-  return read_commandline(static_cast<int>(params.size()),
-                          get_c_string_array(vs).data());
+  auto cvs = get_c_string_array(vs);
+  return read_commandline({cvs.data(), params.size()});
 }
 
 [[nodiscard]] Args get_args_vec(bool const use_syslog) {

--- a/tests/args_test.cpp
+++ b/tests/args_test.cpp
@@ -23,13 +23,14 @@
 #include "to_string.h"
 
 #include <algorithm>
+#include <cppunit/TestAssert.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <string>
 #include <unistd.h>
 
 namespace {
 
-struct Expected_args {
+struct Expected_host_args {
   /** the interface to use */
   std::string interface;
   /** addresses to listen on */
@@ -41,10 +42,9 @@ struct Expected_args {
   std::string hostname;
   unsigned int ping_tries;
   Wol_method wol_method;
-  bool syslog;
 };
 
-void compare(Expected_args const &eargs, Args const &args) {
+void compare(Expected_host_args const &eargs, Host_args const &args) {
   CPPUNIT_ASSERT_EQUAL(eargs.interface, args.interface);
   CPPUNIT_ASSERT_EQUAL(eargs.address, args.address);
   CPPUNIT_ASSERT_EQUAL(eargs.ports, args.ports);
@@ -52,7 +52,6 @@ void compare(Expected_args const &eargs, Args const &args) {
   CPPUNIT_ASSERT_EQUAL(eargs.hostname, args.hostname);
   CPPUNIT_ASSERT_EQUAL(eargs.ping_tries, args.ping_tries);
   CPPUNIT_ASSERT_EQUAL(eargs.wol_method, args.wol_method);
-  CPPUNIT_ASSERT_EQUAL(eargs.syslog, args.syslog);
 }
 
 [[nodiscard]] std::vector<IP_address>
@@ -73,7 +72,7 @@ parse_ports(std::vector<std::string> const &ports) {
   return ret_val;
 }
 
-[[nodiscard]] std::vector<Args> get_args(std::vector<std::string> &params) {
+[[nodiscard]] Args get_args(std::vector<std::string> &params) {
   // reset getopt() to the start
   optind = 0;
   auto vs = to_vector_strings(params);
@@ -81,7 +80,7 @@ parse_ports(std::vector<std::string> const &ports) {
                           get_c_string_array(vs).data());
 }
 
-[[nodiscard]] std::vector<Args> get_args_vec(bool const use_syslog) {
+[[nodiscard]] Args get_args_vec(bool const use_syslog) {
   std::vector<std::string> params{"args_test"};
   if (use_syslog) {
     std::cout << "syslog" << std::endl;
@@ -90,8 +89,8 @@ parse_ports(std::vector<std::string> const &ports) {
   return get_args(params);
 }
 
-[[nodiscard]] std::vector<Args> get_args(const std::string &filename,
-                                         const bool with_syslog = false) {
+[[nodiscard]] Args get_args(const std::string &filename,
+                            const bool with_syslog = false) {
   std::vector<std::string> params{get_executable_path(), "-c",
                                   get_executable_directory() + "/" + filename};
   if (with_syslog) {
@@ -108,21 +107,19 @@ struct Input_args {
   std::string hostname;
   std::string ping_tries;
   std::string wol_method;
-  bool use_syslog;
 
-  [[nodiscard]] Args to_args() const {
+  [[nodiscard]] Host_args to_args() const {
     return {interface, addresses, ports, mac, hostname, ping_tries, wol_method};
   }
 
-  [[nodiscard]] Expected_args to_expected() const {
-    return Expected_args{interface,
-                         parse_ips(addresses),
-                         parse_ports(ports),
-                         mac_to_binary(mac),
-                         hostname,
-                         static_cast<unsigned int>(std::stoul(ping_tries)),
-                         parse_wol_method(wol_method),
-                         use_syslog};
+  [[nodiscard]] Expected_host_args to_expected() const {
+    return Expected_host_args{interface,
+                              parse_ips(addresses),
+                              parse_ports(ports),
+                              mac_to_binary(mac),
+                              hostname,
+                              static_cast<unsigned int>(std::stoul(ping_tries)),
+                              parse_wol_method(wol_method)};
   }
 
   void compare() const { ::compare(to_expected(), to_args()); }
@@ -141,30 +138,30 @@ class Args_test : public CppUnit::TestFixture {
   CPPUNIT_TEST(test_syslog);
   CPPUNIT_TEST(test_read_file);
   CPPUNIT_TEST(test_print_help);
+  CPPUNIT_TEST(test_ostream_operator_with_default_initialized_host_args);
+  CPPUNIT_TEST(test_ostream_operator_with_value_initialized_host_args);
   CPPUNIT_TEST(test_ostream_operator_with_default_initialized_args);
-  CPPUNIT_TEST(test_ostream_operator_with_value_initialized_args);
+  CPPUNIT_TEST(test_ostream_operator_with_empty_args_without_syslog);
+  CPPUNIT_TEST(test_ostream_operator_with_empty_args_with_syslog);
+  CPPUNIT_TEST(test_ostream_operator_with_initialized_args);
   CPPUNIT_TEST(test_read_command_line_weird_option);
   CPPUNIT_TEST_SUITE_END();
 
   Input_args input_args{
       "lo", {"fe80::123/64"}, {"12345"}, "1:12:34:45:67:89", {},
-      "5",  "ethernet",       false};
+      "5",  "ethernet"};
 
 public:
-  void setUp() override {
-    reset();
-    input_args.compare();
-  }
+  void setUp() override { input_args.compare(); }
 
   void tearDown() override {}
 
   static void test_default_constructor() {
-    Args args;
+    Host_args args;
 
     CPPUNIT_ASSERT_EQUAL(ether_addr{{0}}, args.mac);
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), args.ping_tries);
     CPPUNIT_ASSERT_EQUAL(Wol_method::ethernet, args.wol_method);
-    CPPUNIT_ASSERT_EQUAL(false, args.syslog);
   }
 
   void test_interface() {
@@ -178,11 +175,11 @@ public:
 
   void test_addresses() {
     input_args.addresses = std::vector<std::string>{"192.168.1.1"};
-    Args args(input_args.to_args());
+    Host_args args(input_args.to_args());
     input_args.addresses = std::vector<std::string>{"192.168.1.1/24"};
     ::compare(input_args.to_expected(), args);
     input_args.addresses = std::vector<std::string>{"::1"};
-    Args args1(input_args.to_args());
+    Host_args args1(input_args.to_args());
     input_args.addresses = std::vector<std::string>{"::1/128"};
     ::compare(input_args.to_expected(), args1);
     input_args.addresses = std::vector<std::string>{"::1/128;"};
@@ -212,12 +209,12 @@ public:
 
   void test_mac() {
     input_args.mac = "aa:aa:aa:aa:bb:cc";
-    Args args = input_args.to_args();
+    Host_args args = input_args.to_args();
     ::compare(input_args.to_expected(), args);
     input_args.mac = "AA:AA:AA:AA:BB:CC";
     ::compare(input_args.to_expected(), args);
     input_args.mac = "01:2:03:04:05:06";
-    Args args1 = input_args.to_args();
+    Host_args args1 = input_args.to_args();
     input_args.mac = "1:2:3:4:5:6";
     ::compare(input_args.to_expected(), args1);
     input_args.mac = "";
@@ -244,17 +241,13 @@ public:
   }
 
   static void test_syslog() {
-    CPPUNIT_ASSERT(!Args().syslog);
-    auto args = get_args_vec(true);
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), args.size());
-    CPPUNIT_ASSERT(Args().syslog);
-    reset();
-    CPPUNIT_ASSERT(!Args().syslog);
+    CPPUNIT_ASSERT(get_args_vec(true).syslog);
+    CPPUNIT_ASSERT(!get_args_vec(false).syslog);
   }
 
   void test_read_file() {
     auto args = get_args("watchhosts");
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned long>(3), args.size());
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned long>(3), args.host_args.size());
 
     Input_args const arg0{
         "lo",
@@ -263,9 +256,8 @@ public:
         "1:12:34:45:67:89",
         "test.lan",
         "5",
-        "ethernet",
-        input_args.use_syslog};
-    ::compare(arg0.to_expected(), args.at(0));
+        "ethernet"};
+    ::compare(arg0.to_expected(), args.host_args.at(0));
 
     Input_args const arg1{
         "lo",
@@ -274,9 +266,8 @@ public:
         "FF:EE:DD:CC:BB:AA",
         "test2",
         "1",
-        "udp",
-        input_args.use_syslog};
-    ::compare(arg1.to_expected(), args.at(1));
+        "udp"};
+    ::compare(arg1.to_expected(), args.host_args.at(1));
 
     Input_args const arg2{
         "lo",
@@ -285,16 +276,14 @@ public:
         "1:12:34:45:67:89",
         "",
         "5",
-        "ethernet",
-        input_args.use_syslog};
-    ::compare(arg2.to_expected(), args.at(2));
+        "ethernet"};
+    ::compare(arg2.to_expected(), args.host_args.at(2));
 
     auto args2 = get_args("watchhosts-empty");
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned long>(0), args2.size());
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned long>(0), args2.host_args.size());
 
     auto args3 = get_args("watchhosts", true);
-    CPPUNIT_ASSERT_EQUAL(true, args3.at(0).syslog);
-    CPPUNIT_ASSERT_EQUAL(true, args3.at(1).syslog);
+    CPPUNIT_ASSERT(args3.syslog);
   }
 
   static void test_print_help() {
@@ -309,25 +298,59 @@ public:
     CPPUNIT_ASSERT(help_text.size() > 7);
   }
 
-  static void test_ostream_operator_with_default_initialized_args() {
-    Args args;
+  static void test_ostream_operator_with_default_initialized_host_args() {
     std::stringstream ss;
-    ss << args;
+    ss << Host_args{};
     CPPUNIT_ASSERT_EQUAL(
-        std::string("Args(interface = , address = , ports = , mac = "
+        std::string("Host_args(interface = , address = , ports = , mac = "
                     "0:0:0:0:0:0, hostname = , print_tries = 0, wol_method = "
-                    "ethernet, syslog = 0)"),
+                    "ethernet)"),
         ss.str());
   }
 
-  void test_ostream_operator_with_value_initialized_args() {
+  void test_ostream_operator_with_value_initialized_host_args() {
     std::stringstream ss;
     ss << input_args.to_args();
     CPPUNIT_ASSERT_EQUAL(
         std::string(
-            "Args(interface = lo, address = fe80::123/64, ports = 12345, mac = "
+            "Host_args(interface = lo, address = fe80::123/64, ports = 12345, "
+            "mac = "
             "1:12:34:45:67:89, hostname = , print_tries = 5, wol_method = "
-            "ethernet, syslog = 0)"),
+            "ethernet)"),
+        ss.str());
+  }
+
+  static void test_ostream_operator_with_default_initialized_args() {
+    std::stringstream ss;
+    ss << Args{};
+    CPPUNIT_ASSERT_EQUAL(std::string("Args(host_args = [], syslog = false)"),
+                         ss.str());
+  }
+
+  static void test_ostream_operator_with_empty_args_without_syslog() {
+    std::stringstream ss;
+    ss << Args{{}, false};
+    CPPUNIT_ASSERT_EQUAL(std::string("Args(host_args = [], syslog = false)"),
+                         ss.str());
+  }
+
+  static void test_ostream_operator_with_empty_args_with_syslog() {
+    std::stringstream ss;
+    ss << Args{{}, true};
+    CPPUNIT_ASSERT_EQUAL(std::string("Args(host_args = [], syslog = true)"),
+                         ss.str());
+  }
+
+  void test_ostream_operator_with_initialized_args() {
+    std::stringstream ss;
+    ss << Args{{input_args.to_args()}, false};
+    CPPUNIT_ASSERT_EQUAL(
+        std::string(
+            "Args(host_args = [Host_args(interface = lo, address = "
+            "fe80::123/64, ports = 12345, "
+            "mac = "
+            "1:12:34:45:67:89, hostname = , print_tries = 5, wol_method = "
+            "ethernet)], syslog = false)"),
         ss.str());
   }
 
@@ -341,11 +364,11 @@ public:
 
       std::vector<std::string> cmd_args{"weird_option", "-f"};
       auto args = get_args(cmd_args);
-      CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), args.size());
+      CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), args.host_args.size());
 
       cmd_args[1] = "-c";
       auto args1 = get_args(cmd_args);
-      CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), args1.size());
+      CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), args1.host_args.size());
 
       std::cout << std::flush;
     }


### PR DESCRIPTION
Global and Host_args are now decoupled which reduces strange design and clang-tidy findings. The goal was to remove some clang-tidy findings and reduce code duplication.