### PR TITLE
Refactor args test

### DIFF
--- a/tests/args_test.cpp
+++ b/tests/args_test.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <unistd.h>
 
+namespace {
 struct Expected_args {
   /** the interface to use */
   std::string interface;
@@ -53,6 +54,14 @@ void compare(Expected_args const &eargs, Args const &args) {
   CPPUNIT_ASSERT_EQUAL(eargs.syslog, args.syslog);
 }
 
+[[nodiscard]] std::vector<uint16_t>
+parse_ports(std::vector<std::string> ports) {
+  std::vector<uint16_t> ret_val(ports.size());
+  std::transform(std::begin(ports), std::end(ports), std::begin(ret_val),
+                 [](const std::string &s) { return std::stoi(s); });
+  return ret_val;
+}
+
 struct Input_args {
   std::string interface;
   std::vector<std::string> addresses;
@@ -63,6 +72,10 @@ struct Input_args {
   std::string wol_method;
   bool use_syslog;
 
+  [[nodiscard]] Args to_args() const {
+    return {interface, addresses, ports, mac, hostname, ping_tries, wol_method};
+  }
+
   [[nodiscard]] std::vector<IP_address> parse_ips() const {
     std::vector<IP_address> parsed_ips;
     parsed_ips.reserve(addresses.size());
@@ -72,17 +85,10 @@ struct Input_args {
     return parsed_ips;
   }
 
-  [[nodiscard]] std::vector<uint16_t> parse_ports() const {
-    std::vector<uint16_t> ret_val(ports.size());
-    std::transform(std::begin(ports), std::end(ports), std::begin(ret_val),
-                   [](const std::string &s) { return std::stoi(s); });
-    return ret_val;
-  }
-
   [[nodiscard]] Expected_args to_expected() const {
     return Expected_args{interface,
                          parse_ips(),
-                         parse_ports(),
+                         parse_ports(ports),
                          mac_to_binary(mac),
                          hostname,
                          static_cast<unsigned int>(std::stoul(ping_tries)),
@@ -131,12 +137,6 @@ class Args_test : public CppUnit::TestFixture {
     return get_args(params);
   }
 
-  [[nodiscard]] Args get_args() const {
-    return {input_args.interface, input_args.addresses, input_args.ports,
-            input_args.mac,       input_args.hostname,  input_args.ping_tries,
-            input_args.wol_method};
-  }
-
   [[nodiscard]] static std::vector<Args>
   get_args(const std::string &filename, const bool with_syslog = false) {
     std::vector<std::string> params{get_executable_path(), "-c",
@@ -148,14 +148,6 @@ class Args_test : public CppUnit::TestFixture {
     return get_args(params);
   }
 
-  [[nodiscard]] std::vector<uint16_t> parse_ports() const {
-    std::vector<uint16_t> ret_val(input_args.ports.size());
-    std::transform(std::begin(input_args.ports), std::end(input_args.ports),
-                   std::begin(ret_val),
-                   [](const std::string &s) { return std::stoi(s); });
-    return ret_val;
-  }
-
   void compare(const Args &args) const {
     CPPUNIT_ASSERT_EQUAL(input_args.interface, args.interface);
     std::vector<IP_address> parsed_ips;
@@ -164,7 +156,7 @@ class Args_test : public CppUnit::TestFixture {
       parsed_ips.push_back(parse_ip(ip));
     }
     CPPUNIT_ASSERT_EQUAL(parsed_ips, args.address);
-    CPPUNIT_ASSERT_EQUAL(parse_ports(), args.ports);
+    CPPUNIT_ASSERT_EQUAL(parse_ports(input_args.ports), args.ports);
     std::string lower_mac = input_args.mac;
     std::transform(std::begin(lower_mac), std::end(lower_mac),
                    std::begin(lower_mac),
@@ -182,7 +174,7 @@ class Args_test : public CppUnit::TestFixture {
 public:
   void setUp() override {
     reset();
-    compare(get_args());
+    compare(input_args.to_args());
   }
 
   void tearDown() override {}
@@ -197,78 +189,78 @@ public:
 
   void test_interface() {
     input_args.interface = "lo";
-    compare(get_args());
+    compare(input_args.to_args());
     input_args.interface = "lo,eth0";
-    CPPUNIT_ASSERT_THROW(get_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
     input_args.interface = "eth0;";
-    CPPUNIT_ASSERT_THROW(get_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
   }
 
   void test_addresses() {
     input_args.addresses = std::vector<std::string>{"192.168.1.1"};
-    Args args(get_args());
+    Args args(input_args.to_args());
     input_args.addresses = std::vector<std::string>{"192.168.1.1/24"};
     compare(args);
     input_args.addresses = std::vector<std::string>{"::1"};
-    Args args1(get_args());
+    Args args1(input_args.to_args());
     input_args.addresses = std::vector<std::string>{"::1/128"};
     compare(args1);
     input_args.addresses = std::vector<std::string>{"::1/128;"};
-    CPPUNIT_ASSERT_THROW(get_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
     input_args.addresses = std::vector<std::string>{""};
-    CPPUNIT_ASSERT_THROW(get_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
     input_args.addresses = std::vector<std::string>{};
-    CPPUNIT_ASSERT_THROW(get_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
   }
 
   void test_ports() {
     input_args.ports = std::vector<std::string>{"123"};
-    compare(get_args());
+    compare(input_args.to_args());
     input_args.ports = std::vector<std::string>{"123456789"};
-    CPPUNIT_ASSERT_THROW(get_args(), std::out_of_range);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::out_of_range);
     input_args.ports = std::vector<std::string>{"66000"};
-    CPPUNIT_ASSERT_THROW(get_args(), std::out_of_range);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::out_of_range);
     input_args.ports = std::vector<std::string>{"12345;"};
-    CPPUNIT_ASSERT_THROW(get_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
     input_args.ports = std::vector<std::string>{"garbage"};
-    CPPUNIT_ASSERT_THROW(get_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
     input_args.ports = std::vector<std::string>{""};
-    CPPUNIT_ASSERT_THROW(get_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
     input_args.ports = std::vector<std::string>{};
-    CPPUNIT_ASSERT_THROW(get_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
   }
 
   void test_mac() {
     input_args.mac = "aa:aa:aa:aa:bb:cc";
-    Args args = get_args();
+    Args args = input_args.to_args();
     compare(args);
     input_args.mac = "AA:AA:AA:AA:BB:CC";
     compare(args);
     input_args.mac = "01:2:03:04:05:06";
-    Args args1 = get_args();
+    Args args1 = input_args.to_args();
     input_args.mac = "1:2:3:4:5:6";
     compare(args1);
     input_args.mac = "";
-    CPPUNIT_ASSERT_THROW(get_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
   }
 
   void test_hostname() {
     input_args.hostname = "asdf,.-";
-    CPPUNIT_ASSERT_THROW(get_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
   }
 
   void test_ping_tries() {
     input_args.ping_tries = "1111111111111111111111";
-    CPPUNIT_ASSERT_THROW(get_args(), std::out_of_range);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::out_of_range);
     input_args.ping_tries = "";
-    CPPUNIT_ASSERT_THROW(get_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
   }
 
   void test_wol_method() {
     input_args.wol_method = "unknown";
-    CPPUNIT_ASSERT_THROW(get_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
     input_args.wol_method = "";
-    CPPUNIT_ASSERT_THROW(get_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
   }
 
   void test_syslog() {
@@ -284,35 +276,39 @@ public:
   void test_read_file() {
     auto args = get_args("watchhosts");
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned long>(3), args.size());
-    input_args.interface = "lo";
-    input_args.addresses =
-        std::vector<std::string>{"10.0.0.1/16", "fe80::123/64"};
-    input_args.ports = std::vector<std::string>{"12345", "23456"};
-    input_args.mac = "1:12:34:45:67:89";
-    input_args.hostname = "test.lan";
-    input_args.ping_tries = "5";
-    input_args.wol_method = "ethernet";
-    compare(args.at(0));
 
-    input_args.interface = "lo";
-    input_args.addresses =
-        std::vector<std::string>{"10.1.2.3/16", "fe80::de:ad/64"};
-    input_args.ports = std::vector<std::string>{"22"};
-    input_args.mac = "FF:EE:DD:CC:BB:AA";
-    input_args.hostname = "test2";
-    input_args.ping_tries = "1";
-    input_args.wol_method = "udp";
-    compare(args.at(1));
+    Input_args const arg0{
+        "lo",
+        std::vector<std::string>{"10.0.0.1/16", "fe80::123/64"},
+        std::vector<std::string>{"12345", "23456"},
+        "1:12:34:45:67:89",
+        "test.lan",
+        "5",
+        "ethernet",
+        input_args.use_syslog};
+    ::compare(arg0.to_expected(), args.at(0));
 
-    input_args.interface = "lo";
-    input_args.addresses =
-        std::vector<std::string>{"10.0.0.1/16", "fe80::123/64"};
-    input_args.ports = std::vector<std::string>{"12345", "23456"};
-    input_args.mac = "1:12:34:45:67:89";
-    input_args.hostname = "";
-    input_args.ping_tries = "5";
-    input_args.wol_method = "ethernet";
-    compare(args.at(2));
+    Input_args const arg1{
+        "lo",
+        std::vector<std::string>{"10.1.2.3/16", "fe80::de:ad/64"},
+        std::vector<std::string>{"22"},
+        "FF:EE:DD:CC:BB:AA",
+        "test2",
+        "1",
+        "udp",
+        input_args.use_syslog};
+    ::compare(arg1.to_expected(), args.at(1));
+
+    Input_args const arg2{
+        "lo",
+        std::vector<std::string>{"10.0.0.1/16", "fe80::123/64"},
+        std::vector<std::string>{"12345", "23456"},
+        "1:12:34:45:67:89",
+        "",
+        "5",
+        "ethernet",
+        input_args.use_syslog};
+    ::compare(arg2.to_expected(), args.at(2));
 
     auto args2 = get_args("watchhosts-empty");
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned long>(0), args2.size());
@@ -347,7 +343,7 @@ public:
 
   void test_ostream_operator_with_value_initialized_args() {
     std::stringstream ss;
-    ss << get_args();
+    ss << input_args.to_args();
     CPPUNIT_ASSERT_EQUAL(
         std::string(
             "Args(interface = lo, address = fe80::123/64, ports = 12345, mac = "
@@ -385,3 +381,5 @@ public:
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(Args_test);
+
+} // namespace

--- a/tests/args_test.cpp
+++ b/tests/args_test.cpp
@@ -171,9 +171,9 @@ public:
     input_args.interface = "lo";
     input_args.compare();
     input_args.interface = "lo,eth0";
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::runtime_error);
     input_args.interface = "eth0;";
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::runtime_error);
   }
 
   void test_addresses() {
@@ -186,28 +186,28 @@ public:
     input_args.addresses = std::vector<std::string>{"::1/128"};
     ::compare(input_args.to_expected(), args1);
     input_args.addresses = std::vector<std::string>{"::1/128;"};
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::runtime_error);
     input_args.addresses = std::vector<std::string>{""};
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::invalid_argument);
     input_args.addresses = std::vector<std::string>{};
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::runtime_error);
   }
 
   void test_ports() {
     input_args.ports = std::vector<std::string>{"123"};
     input_args.compare();
     input_args.ports = std::vector<std::string>{"123456789"};
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::out_of_range);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::out_of_range);
     input_args.ports = std::vector<std::string>{"66000"};
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::out_of_range);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::out_of_range);
     input_args.ports = std::vector<std::string>{"12345;"};
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::invalid_argument);
     input_args.ports = std::vector<std::string>{"garbage"};
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::invalid_argument);
     input_args.ports = std::vector<std::string>{""};
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::invalid_argument);
     input_args.ports = std::vector<std::string>{};
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::runtime_error);
   }
 
   void test_mac() {
@@ -221,26 +221,26 @@ public:
     input_args.mac = "1:2:3:4:5:6";
     ::compare(input_args.to_expected(), args1);
     input_args.mac = "";
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::runtime_error);
   }
 
   void test_hostname() {
     input_args.hostname = "asdf,.-";
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::runtime_error);
   }
 
   void test_ping_tries() {
     input_args.ping_tries = "1111111111111111111111";
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::out_of_range);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::out_of_range);
     input_args.ping_tries = "";
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::invalid_argument);
   }
 
   void test_wol_method() {
     input_args.wol_method = "unknown";
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::invalid_argument);
     input_args.wol_method = "";
-    CPPUNIT_ASSERT_THROW(input_args.to_args(), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)input_args.to_args(), std::invalid_argument);
   }
 
   static void test_syslog() {

--- a/tests/ethernet_test.cpp
+++ b/tests/ethernet_test.cpp
@@ -270,7 +270,8 @@ public:
   static void test_mac_to_binary() {
     std::string const mac = "00:11:Aa:Cd:65:43";
     ether_addr const binary = mac_to_binary(mac);
-    std::array<uint8_t, 6> const expected_mac{{0, 17, 170, 205, 101, 67}};
+    std::array<uint8_t, 6> const expected_mac{
+        {0x0, 0x11, 0xaa, 0xcd, 0x65, 0x43}};
     CPPUNIT_ASSERT(std::equal(std::begin(expected_mac), std::end(expected_mac),
                               std::begin(binary.ether_addr_octet)));
 
@@ -287,7 +288,7 @@ public:
   }
 
   static void test_binary_to_mac() {
-    ether_addr const binary{{0, 17, 170, 205, 101, 67}};
+    ether_addr const binary{{0x0, 0x11, 0xaa, 0xcd, 0x65, 0x43}};
     CPPUNIT_ASSERT_EQUAL(std::string("0:11:aa:cd:65:43"),
                          binary_to_mac(binary));
   }


### PR DESCRIPTION
Args and their test make too much use of member variables and globals. This needs slowly to change. Also functions only should have a single responsibility.