### PR TITLE
Fix clang-tidy warnings after changing to C++20

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,7 +19,11 @@ Checks:          'clang-diagnostic-*,
                   # min and max values at some functions have the same type and trigger check,
                   -readability-suspicious-call-argument,
                   # many variables have a short name, too hard to fix,
-                  -readability-identifier-length'
+                  -readability-identifier-length,
+                  # triggered when using structs defined by C / POSIX,
+                  -cppcoreguidelines-pro-type-union-access,
+                  # too many code atm,
+                  -cppcoreguidelines-avoid-const-or-ref-data-members'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/src/include/args.h
+++ b/src/include/args.h
@@ -62,14 +62,14 @@ struct Args {
   const bool syslog;
 };
 
-Host_args parse_host_args(const std::string &interface_,
-                          const std::vector<std::string> &addresss_,
-                          const std::vector<std::string> &ports_,
-                          const std::string &mac_, const std::string &hostname_,
-                          const std::string &ping_tries_,
-                          const std::string &wol_method_);
+[[nodiscard]] Host_args
+parse_host_args(const std::string &interface_,
+                const std::vector<std::string> &addresss_,
+                const std::vector<std::string> &ports_, const std::string &mac_,
+                const std::string &hostname_, const std::string &ping_tries_,
+                const std::string &wol_method_);
 
-Args read_commandline(std::span<char *> const &args);
+[[nodiscard]] Args read_commandline(std::span<char *> const &args);
 
 /**
  * write args into out

--- a/src/include/container_utils.h
+++ b/src/include/container_utils.h
@@ -24,10 +24,10 @@
 #include <string>
 #include <vector>
 
-template <typename T> T identity(const T &t) { return t; }
+template <typename T> [[nodiscard]] T identity(const T &t) { return t; }
 
 template <typename Container, typename Func>
-std::string join(Container c, Func fun, const std::string &sep) {
+[[nodiscard]] std::string join(Container c, Func fun, const std::string &sep) {
   using input_type = typename std::result_of<decltype(fun)(
       typename Container::value_type)>::type;
   std::stringstream ss;
@@ -41,8 +41,8 @@ std::string join(Container c, Func fun, const std::string &sep) {
 }
 
 template <typename T, typename Alloc>
-std::vector<T, Alloc> operator+(std::vector<T, Alloc> &&lhs,
-                                const std::vector<T, Alloc> &rhs) {
+[[nodiscard]] std::vector<T, Alloc>
+operator+(std::vector<T, Alloc> &&lhs, const std::vector<T, Alloc> &rhs) {
   lhs.insert(std::end(lhs), std::begin(rhs), std::end(rhs));
   return std::move(lhs);
 }
@@ -57,8 +57,8 @@ void check_type_and_range(iterator data, iterator end, size_t const min_size) {
 }
 
 template <typename Container>
-std::vector<Container> split(Container const &c,
-                             typename Container::value_type const &delimiter) {
+[[nodiscard]] std::vector<Container>
+split(Container const &c, typename Container::value_type const &delimiter) {
   typename Container::const_iterator iter{std::begin(c)};
   std::vector<Container> results;
   while (iter != std::end(c)) {

--- a/src/include/duplicate_address_watcher.h
+++ b/src/include/duplicate_address_watcher.h
@@ -24,13 +24,14 @@
 #include <string>
 #include <thread>
 
-std::string get_mac(std::string const &iface);
+[[nodiscard]] std::string get_mac(std::string const &iface);
 
 using Is_ip_occupied =
     std::function<bool(std::string const &, IP_address const &)>;
 
-bool contains_mac_different_from_given(std::string mac,
-                                       std::vector<std::string> const &lines);
+[[nodiscard]] bool
+contains_mac_different_from_given(std::string mac,
+                                  std::vector<std::string> const &lines);
 
 void daw_thread_main_ipv6(const std::string &iface, const IP_address &ip,
                           Is_ip_occupied const &is_ip_occupied,
@@ -45,11 +46,14 @@ struct Ip_neigh_checker {
 
   explicit Ip_neigh_checker(std::string mac);
 
-  static bool is_ipv4_present(std::string const &iface, IP_address const &ip);
+  [[nodiscard]] static bool is_ipv4_present(std::string const &iface,
+                                            IP_address const &ip);
 
-  bool is_ipv6_present(std::string const &iface, IP_address const &ip) const;
+  [[nodiscard]] bool is_ipv6_present(std::string const &iface,
+                                     IP_address const &ip) const;
 
-  bool operator()(std::string const &iface, IP_address const &ip) const;
+  [[nodiscard]] bool operator()(std::string const &iface,
+                                IP_address const &ip) const;
 };
 
 struct Duplicate_address_watcher {
@@ -75,7 +79,7 @@ struct Duplicate_address_watcher {
   operator=(Duplicate_address_watcher const &) = delete;
   Duplicate_address_watcher &operator=(Duplicate_address_watcher &&) = delete;
 
-  std::string operator()(Action action);
+  [[nodiscard]] std::string operator()(Action action);
 
   void stop_watcher();
 };

--- a/src/include/ethernet.h
+++ b/src/include/ethernet.h
@@ -42,30 +42,30 @@ struct Link_layer {
   Link_layer(size_t header_length, ether_addr source, uint16_t payload_protocol,
              std::string info);
 
-  size_t header_length() const;
+  [[nodiscard]] size_t header_length() const;
 
-  uint16_t payload_protocol() const;
+  [[nodiscard]] uint16_t payload_protocol() const;
 
-  std::string get_info() const;
+  [[nodiscard]] std::string get_info() const;
 
-  ether_addr source() const;
+  [[nodiscard]] ether_addr source() const;
 };
 
 std::ostream &operator<<(std::ostream &out, const Link_layer &ll);
 
-std::vector<uint8_t> create_ethernet_header(const ether_addr &dmac,
-                                            const ether_addr &smac,
-                                            uint16_t type);
+[[nodiscard]] std::vector<uint8_t>
+create_ethernet_header(const ether_addr &dmac, const ether_addr &smac,
+                       uint16_t type);
 
-std::vector<uint8_t> to_vector(const ether_addr &mac);
+[[nodiscard]] std::vector<uint8_t> to_vector(const ether_addr &mac);
 
-ether_addr mac_to_binary(const std::string &mac);
+[[nodiscard]] ether_addr mac_to_binary(const std::string &mac);
 
-std::string binary_to_mac(const ether_addr &mac);
+[[nodiscard]] std::string binary_to_mac(const ether_addr &mac);
 
 template <typename iterator>
-std::unique_ptr<Link_layer> parse_linux_cooked_capture(iterator data,
-                                                       iterator end) {
+[[nodiscard]] std::unique_ptr<Link_layer>
+parse_linux_cooked_capture(iterator data, iterator end) {
   // see https://www.tcpdump.org/linktypes/LINKTYPE_LINUX_SLL.html
   check_type_and_range(data, end, Link_layer::lcc_header_size);
   std::advance(data, 2);
@@ -99,7 +99,8 @@ std::unique_ptr<Link_layer> parse_linux_cooked_capture(iterator data,
 }
 
 template <typename iterator>
-std::unique_ptr<Link_layer> parse_ethernet(iterator data, iterator end) {
+[[nodiscard]] std::unique_ptr<Link_layer> parse_ethernet(iterator data,
+                                                         iterator end) {
   size_t const header_size = 14;
   check_type_and_range(data, end, header_size);
   ether_addr ether_dhost{};
@@ -120,7 +121,8 @@ std::unique_ptr<Link_layer> parse_ethernet(iterator data, iterator end) {
 }
 
 template <typename iterator>
-std::unique_ptr<Link_layer> parse_VLAN_Header(iterator data, iterator end) {
+[[nodiscard]] std::unique_ptr<Link_layer> parse_VLAN_Header(iterator data,
+                                                            iterator end) {
   size_t const header_size = 4;
   check_type_and_range(data, end, header_size);
   std::advance(data, 2);
@@ -133,8 +135,8 @@ std::unique_ptr<Link_layer> parse_VLAN_Header(iterator data, iterator end) {
 }
 
 template <typename iterator>
-std::unique_ptr<Link_layer> parse_link_layer(const int type, iterator data,
-                                             iterator end) {
+[[nodiscard]] std::unique_ptr<Link_layer>
+parse_link_layer(const int type, iterator data, iterator end) {
   switch (type) {
   case DLT_LINUX_SLL:
     return parse_linux_cooked_capture(data, end);

--- a/src/include/file_descriptor.h
+++ b/src/include/file_descriptor.h
@@ -41,14 +41,14 @@ struct File_descriptor {
 
   void close();
 
-  std::vector<std::string> read() const;
+  [[nodiscard]] std::vector<std::string> read() const;
 };
 
-bool file_exists(const std::string &filename);
+[[nodiscard]] bool file_exists(const std::string &filename);
 
-std::tuple<File_descriptor, File_descriptor>
+[[nodiscard]] std::tuple<File_descriptor, File_descriptor>
 get_self_pipes(bool close_on_exec = true);
 
-int get_fd_from_stream(FILE *stream);
+[[nodiscard]] int get_fd_from_stream(FILE *stream);
 
 void flush_file(FILE *stream);

--- a/src/include/int_utils.h
+++ b/src/include/int_utils.h
@@ -23,13 +23,15 @@
 #include <string>
 
 static auto const base_10 = int{10};
-int64_t stoll_with_checks(const std::string &s, int base = base_10);
-uint64_t stoull_with_checks(const std::string &s, int base = base_10);
+[[nodiscard]] int64_t stoll_with_checks(const std::string &s,
+                                        int base = base_10);
+[[nodiscard]] uint64_t stoull_with_checks(const std::string &s,
+                                          int base = base_10);
 
 /** range check for signed target types */
 template <typename R, typename T,
           typename std::enable_if<std::is_signed<T>::value>::type * = nullptr>
-bool within_bounds(const T &val) noexcept {
+[[nodiscard]] bool within_bounds(const T &val) noexcept {
   return std::numeric_limits<R>::lowest() <= val &&
          val <= std::numeric_limits<R>::max();
 }
@@ -37,26 +39,27 @@ bool within_bounds(const T &val) noexcept {
 /** range check for unsigned target types */
 template <typename R, typename T,
           typename std::enable_if<std::is_unsigned<T>::value>::type * = nullptr>
-bool within_bounds(const T &val) noexcept {
+[[nodiscard]] bool within_bounds(const T &val) noexcept {
   return val <= std::numeric_limits<R>::max();
 }
 
 /** convert to signed types */
 template <typename T,
           typename std::enable_if<std::is_signed<T>::value>::type * = nullptr>
-int64_t str_to_integral_helper(const std::string &string) {
+[[nodiscard]] int64_t str_to_integral_helper(const std::string &string) {
   return stoll_with_checks(string);
 }
 
 /** convert to unsigned types */
 template <typename T,
           typename std::enable_if<std::is_unsigned<T>::value>::type * = nullptr>
-uint64_t str_to_integral_helper(const std::string &string) {
+[[nodiscard]] uint64_t str_to_integral_helper(const std::string &string) {
   return stoull_with_checks(string);
 }
 
 /** converts string to any integral type */
-template <typename T> T str_to_integral(const std::string &string) {
+template <typename T>
+[[nodiscard]] T str_to_integral(const std::string &string) {
   auto value = str_to_integral_helper<T>(string);
   if (!within_bounds<T>(value)) {
     std::string mess = "value " + to_string(value) + " not in range " +
@@ -67,4 +70,4 @@ template <typename T> T str_to_integral(const std::string &string) {
   return static_cast<T>(value);
 }
 
-std::string uint32_t_to_eight_hex_chars(uint32_t i) noexcept;
+[[nodiscard]] std::string uint32_t_to_eight_hex_chars(uint32_t i) noexcept;

--- a/src/include/ip.h
+++ b/src/include/ip.h
@@ -45,27 +45,27 @@ struct ip {
      IP_address destination, uint8_t payload_protocol);
 
   /** which IP version */
-  Version version() const;
+  [[nodiscard]] Version version() const;
 
   /** length of IP header in bytes */
-  size_t header_length() const;
+  [[nodiscard]] size_t header_length() const;
 
   /** source address */
-  IP_address source() const;
+  [[nodiscard]] IP_address source() const;
 
   /** destination address */
-  IP_address destination() const;
+  [[nodiscard]] IP_address destination() const;
 
   /** which protocol header to expect next */
-  uint8_t payload_protocol() const;
+  [[nodiscard]] uint8_t payload_protocol() const;
 };
 
 /** writes ip into out which every information available to the base class */
 std::ostream &operator<<(std::ostream &out, const ip &ip);
 
 template <typename iterator>
-bool ethernet_payload_and_ip_version_dont_match(uint16_t const type,
-                                                iterator data) {
+[[nodiscard]] bool
+ethernet_payload_and_ip_version_dont_match(uint16_t const type, iterator data) {
   static_assert(std::is_same<typename iterator::value_type, uint8_t>::value,
                 "container has to carry u_char or uint8_t");
 
@@ -78,10 +78,10 @@ bool ethernet_payload_and_ip_version_dont_match(uint16_t const type,
   return result;
 }
 
-IP_address get_ipv6_address(const in6_addr &addr);
+[[nodiscard]] IP_address get_ipv6_address(const in6_addr &addr);
 
 template <typename iterator>
-std::unique_ptr<ip> parse_ipv4(iterator data, iterator end) {
+[[nodiscard]] std::unique_ptr<ip> parse_ipv4(iterator data, iterator end) {
   check_type_and_range(data, end, ip::ipv4_header_size);
   uint8_t const ip_vhl = *data;
   size_t const header_length = static_cast<uint8_t>((ip_vhl & 0x0f) * 4);
@@ -101,7 +101,7 @@ std::unique_ptr<ip> parse_ipv4(iterator data, iterator end) {
 }
 
 template <typename iterator>
-std::unique_ptr<ip> parse_ipv6(iterator data, iterator end) {
+[[nodiscard]] std::unique_ptr<ip> parse_ipv6(iterator data, iterator end) {
   check_type_and_range(data, end, ip::ipv6_header_size);
   // NOLINTNEXTLINE
   std::advance(data, 6);
@@ -120,7 +120,8 @@ std::unique_ptr<ip> parse_ipv6(iterator data, iterator end) {
 }
 
 template <typename iterator>
-std::unique_ptr<ip> parse_ip(uint16_t const type, iterator data, iterator end) {
+[[nodiscard]] std::unique_ptr<ip> parse_ip(uint16_t const type, iterator data,
+                                           iterator end) {
   // check wether type and the version the ip headers matches
   if (ethernet_payload_and_ip_version_dont_match(type, data)) {
     return nullptr;

--- a/src/include/ip_address.h
+++ b/src/include/ip_address.h
@@ -29,15 +29,15 @@ struct IP_address {
   } address;
   uint8_t subnet;
 
-  std::string pure() const;
+  [[nodiscard]] std::string pure() const;
 
-  std::string with_subnet() const;
+  [[nodiscard]] std::string with_subnet() const;
 
-  bool operator==(const IP_address &rhs) const;
+  [[nodiscard]] bool operator==(const IP_address &rhs) const;
 };
 
-IP_address parse_ip(const std::string &ip);
+[[nodiscard]] IP_address parse_ip(const std::string &ip);
 
-std::string get_pure_ip(const IP_address &ip);
+[[nodiscard]] std::string get_pure_ip(const IP_address &ip);
 
 std::ostream &operator<<(std::ostream &out, const IP_address &ipa);

--- a/src/include/ip_utils.h
+++ b/src/include/ip_utils.h
@@ -27,7 +27,7 @@ static const std::string iface_chars{"qwertzuiopasdfghjklyxcvbnm.-0123456789"};
 std::string validate_iface(std::string const &iface);
 
 template <typename Container, typename Func>
-auto parse_items(Container &&items, Func &&parser) -> std::vector<
+[[nodiscard]] auto parse_items(Container &&items, Func &&parser) -> std::vector<
     typename std::invoke_result_t<decltype(parser), const std::string &>> {
   static_assert(std::is_same<typename std::decay<Container>::type::value_type,
                              std::string>::value,

--- a/src/include/libsleep_proxy.h
+++ b/src/include/libsleep_proxy.h
@@ -24,17 +24,19 @@
 
 void setup_signals();
 
-bool is_signaled();
+[[nodiscard]] bool is_signaled();
 
 void reset_signaled();
 
-std::string get_bindable_ip(const std::string &iface, const std::string &ip);
+[[nodiscard]] std::string get_bindable_ip(const std::string &iface,
+                                          const std::string &ip);
 
-std::string rule_to_listen_on_ips_and_ports(const std::vector<IP_address> &ips,
-                                            const std::vector<uint16_t> &ports);
+[[nodiscard]] std::string
+rule_to_listen_on_ips_and_ports(const std::vector<IP_address> &ips,
+                                const std::vector<uint16_t> &ports);
 
-bool ping_and_wait(const std::string &iface, const IP_address &ip,
-                   unsigned int tries);
+[[nodiscard]] bool ping_and_wait(const std::string &iface, const IP_address &ip,
+                                 unsigned int tries);
 
 enum class Emulate_host_status {
   success,

--- a/src/include/packet_parser.h
+++ b/src/include/packet_parser.h
@@ -37,7 +37,8 @@ std::ostream &operator<<(std::ostream &out, const basic_headers &headers);
 /**
  * Extracts the Ethernet, IP and TCP/UDP headers from packet
  * */
-basic_headers get_headers(int type, const std::vector<u_char> &packet);
+[[nodiscard]] basic_headers get_headers(int type,
+                                        const std::vector<u_char> &packet);
 
 /**
  * Saves the lower 3 layers and all the data which has been intercepted

--- a/src/include/pcap_wrapper.h
+++ b/src/include/pcap_wrapper.h
@@ -48,7 +48,7 @@ protected:
   /** this is only present to run tests as non-root, do not use */
   Pcap_wrapper();
 
-  Loop_end_reason get_end_reason() const;
+  [[nodiscard]] Loop_end_reason get_end_reason() const;
 
 public:
   static auto const default_snaplen = int{65000};
@@ -67,9 +67,9 @@ public:
   Pcap_wrapper &operator=(Pcap_wrapper &&) = default;
 
   /** tell if the first header is ethernet, unix socket, ... */
-  int get_datalink() const;
+  [[nodiscard]] int get_datalink() const;
 
-  std::string get_verbose_datalink() const;
+  [[nodiscard]] std::string get_verbose_datalink() const;
 
   /** sets a BPF (berkeley packet filter) filter the pcap instance */
   void set_filter(const std::string &filter);

--- a/src/include/scope_guard.h
+++ b/src/include/scope_guard.h
@@ -125,7 +125,7 @@ template <typename Cont, typename T> struct Ptr_guard {
   std::mutex &cont_mutex;
   T &ref;
 
-  std::string operator()(const Action action) {
+  [[nodiscard]] std::string operator()(const Action action) {
     const std::lock_guard<std::mutex> lock(cont_mutex);
     switch (action) {
     case Action::add:
@@ -148,18 +148,21 @@ template <typename Cont, typename T> struct Ptr_guard {
 };
 
 template <typename Cont, typename T>
-Ptr_guard<Cont, T> ptr_guard(Cont &cont, std::mutex &cont_mutex, T &ref) {
+[[nodiscard]] Ptr_guard<Cont, T> ptr_guard(Cont &cont, std::mutex &cont_mutex,
+                                           T &ref) {
   return Ptr_guard<Cont, T>{cont, cont_mutex, ref};
 }
 
 template <typename FUNCTOR> struct Moveable_functor_wrapper {
   std::shared_ptr<FUNCTOR> functor;
 
-  std::string operator()(const Action action) { return (*functor)(action); }
+  [[nodiscard]] std::string operator()(const Action action) {
+    return (*functor)(action);
+  }
 };
 
 template <typename MOVEABLE, typename... ARGS>
-Moveable_functor_wrapper<MOVEABLE> make_copyable(ARGS... args) {
+[[nodiscard]] Moveable_functor_wrapper<MOVEABLE> make_copyable(ARGS... args) {
   return Moveable_functor_wrapper<MOVEABLE>{
       std::make_shared<MOVEABLE>(args...)};
 }

--- a/src/include/socket.h
+++ b/src/include/socket.h
@@ -70,8 +70,8 @@ public:
    * send buf to dest_addr
    */
   template <typename Sockaddr>
-  void send_to(const std::vector<uint8_t> &buf, int flags,
-               Sockaddr &&sockaddr) {
+  ssize_t send_to(const std::vector<uint8_t> &buf, int flags,
+                  Sockaddr &&sockaddr) {
     ssize_t sent_bytes = sendto(
         sock, buf.data(), buf.size(), flags,
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -80,6 +80,7 @@ public:
       throw std::runtime_error(std::string("sendto() failed: ") +
                                strerror(errno));
     }
+    return sent_bytes;
   }
 
   void ioctl(unsigned long req_number, ifreq &ifr) const;

--- a/src/include/socket.h
+++ b/src/include/socket.h
@@ -30,7 +30,7 @@ class Socket {
   int sock;
 
 protected:
-  int fd() const;
+  [[nodiscard]] int fd() const;
 
 public:
   /** open a socket */
@@ -70,8 +70,8 @@ public:
    * send buf to dest_addr
    */
   template <typename Sockaddr>
-  ssize_t send_to(const std::vector<uint8_t> &buf, int flags,
-                  Sockaddr &&sockaddr) {
+  void send_to(const std::vector<uint8_t> &buf, int flags,
+               Sockaddr &&sockaddr) {
     ssize_t sent_bytes = sendto(
         sock, buf.data(), buf.size(), flags,
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -80,12 +80,11 @@ public:
       throw std::runtime_error(std::string("sendto() failed: ") +
                                strerror(errno));
     }
-    return sent_bytes;
   }
 
   void ioctl(unsigned long req_number, ifreq &ifr) const;
 
-  int get_ifindex(const std::string &iface) const;
+  [[nodiscard]] int get_ifindex(const std::string &iface) const;
 
-  ether_addr get_hwaddr(const std::string &iface) const;
+  [[nodiscard]] ether_addr get_hwaddr(const std::string &iface) const;
 };

--- a/src/include/spawn_process.h
+++ b/src/include/spawn_process.h
@@ -23,10 +23,11 @@
 #include <string>
 #include <type_traits>
 
-uint8_t wait_until_pid_exits(const pid_t &pid);
+[[nodiscard]] uint8_t wait_until_pid_exits(const pid_t &pid);
 
-uint8_t spawn_wrapper(std::vector<char *> params, File_descriptor const &in,
-                      File_descriptor const &out);
+[[nodiscard]] uint8_t spawn_wrapper(std::vector<char *> params,
+                                    File_descriptor const &in,
+                                    File_descriptor const &out);
 
 template <typename Container>
 uint8_t spawn(Container &&cmd, File_descriptor const &in = File_descriptor(),

--- a/src/include/to_string.h
+++ b/src/include/to_string.h
@@ -36,23 +36,24 @@ std::ostream &operator<<(std::ostream &out, std::vector<T, Alloc> v) {
   return out;
 }
 
-std::string to_string(char const *t);
+[[nodiscard]] std::string to_string(char const *t);
 
-template <typename T> std::string to_string(T &&t) {
+template <typename T> [[nodiscard]] std::string to_string(T &&t) {
   std::stringstream ss;
   ss << t;
   return ss.str();
 }
 
-bool contains_only_valid_characters(const std::string &input,
-                                    const std::string &valid_chars);
+[[nodiscard]] bool
+contains_only_valid_characters(const std::string &input,
+                               const std::string &valid_chars);
 
 std::string test_characters(const std::string &input,
                             const std::string &valid_chars,
                             const std::string &error_message);
 
 template <typename Container>
-std::vector<std::vector<std::string::value_type>>
+[[nodiscard]] std::vector<std::vector<std::string::value_type>>
 to_vector_strings(Container &&cont) {
   auto const conv = [](std::string const &s) {
     auto result =
@@ -69,7 +70,7 @@ to_vector_strings(Container &&cont) {
 }
 
 template <typename Container>
-std::vector<char *> get_c_string_array(Container &cont) {
+[[nodiscard]] std::vector<char *> get_c_string_array(Container &cont) {
   static_assert(std::is_same<typename std::decay<Container>::type::value_type,
                              std::vector<std::string::value_type>>::value,
                 "container has to carry std::vector<std::string::value_type>");

--- a/src/include/wol.h
+++ b/src/include/wol.h
@@ -26,13 +26,14 @@ enum class Wol_method { ethernet, udp };
 /**
  * create the payload for a UDP wol packet to be broadcast in to the network
  */
-std::vector<uint8_t> create_wol_payload(const ether_addr &mac);
+[[nodiscard]] std::vector<uint8_t> create_wol_payload(const ether_addr &mac);
 
 /**
  * validates and converts human readable wol method into its respective enum
  * value
  */
-Wol_method parse_wol_method(const std::string &wol_method);
+[[nodiscard]] Wol_method parse_wol_method(const std::string &wol_method);
+
 std::ostream &operator<<(std::ostream &out, const Wol_method &wol_method);
 
 /**

--- a/src/include/wol_watcher.h
+++ b/src/include/wol_watcher.h
@@ -21,7 +21,8 @@
 #include <string>
 #include <thread>
 
-bool is_magic_packet(std::vector<uint8_t> const &data, ether_addr const &mac);
+[[nodiscard]] bool is_magic_packet(std::vector<uint8_t> const &data,
+                                   ether_addr const &mac);
 
 void break_on_magic_packet(const struct pcap_pkthdr *header,
                            const u_char *packet, ether_addr const &mac,
@@ -50,7 +51,7 @@ struct Wol_watcher {
   Wol_watcher &operator=(Wol_watcher const &) = delete;
   Wol_watcher &operator=(Wol_watcher &&) = delete;
 
-  std::string operator()(Action action);
+  [[nodiscard]] std::string operator()(Action action);
 
   void stop();
 };

--- a/src/sleep-proxy/spawn_process.cpp
+++ b/src/sleep-proxy/spawn_process.cpp
@@ -25,13 +25,13 @@
 
 uint8_t wait_until_pid_exits(const pid_t &pid) {
   int status = -1;
-  do {
+  while (!WIFEXITED(status) && !WIFSIGNALED(status)) {
     pid_t wpid = waitpid(pid, &status, 0);
     if (wpid == -1) {
       throw std::runtime_error(std::string("waitpid() failed: ") +
                                strerror(errno));
     }
-  } while (!WIFEXITED(status) && !WIFSIGNALED(status));
+  }
   if (WIFSIGNALED(status)) {
     raise(WTERMSIG(status));
   }

--- a/tests/duplicate_address_watcher_test.cpp
+++ b/tests/duplicate_address_watcher_test.cpp
@@ -179,7 +179,7 @@ public:
     CPPUNIT_ASSERT(Pcap_wrapper::Loop_end_reason::unset ==
                    pcap.get_end_reason());
     CPPUNIT_ASSERT(!daw.loop);
-    { daw(Action::add); }
+    CPPUNIT_ASSERT_EQUAL(std::string{}, daw(Action::add));
     std::this_thread::sleep_for(sleep_100);
     CPPUNIT_ASSERT(Pcap_wrapper::Loop_end_reason::signal ==
                    pcap.get_end_reason());

--- a/tests/ethernet_test.cpp
+++ b/tests/ethernet_test.cpp
@@ -85,9 +85,9 @@ class Ethernet_test : public CppUnit::TestFixture {
 
 public:
   void test_parse_lcc_not_supported() {
-    CPPUNIT_ASSERT_THROW(parse_link_layer(DLT_LINUX_SLL,
-                                          std::begin(lcc_not_supported),
-                                          std::end(lcc_not_supported)),
+    CPPUNIT_ASSERT_THROW((void)parse_link_layer(DLT_LINUX_SLL,
+                                                std::begin(lcc_not_supported),
+                                                std::end(lcc_not_supported)),
                          std::runtime_error);
   }
 
@@ -113,20 +113,23 @@ public:
   }
 
   void test_parse_lcc_ipv4_2() {
-    CPPUNIT_ASSERT_THROW(parse_link_layer(DLT_LINUX_SLL, std::begin(lcc_ipv4_2),
-                                          std::end(lcc_ipv4_2)),
+    CPPUNIT_ASSERT_THROW((void)parse_link_layer(DLT_LINUX_SLL,
+                                                std::begin(lcc_ipv4_2),
+                                                std::end(lcc_ipv4_2)),
                          std::length_error);
   }
 
   void test_parse_lcc_ipv4_3() {
-    CPPUNIT_ASSERT_THROW(parse_link_layer(DLT_LINUX_SLL, std::begin(lcc_ipv4_3),
-                                          std::end(lcc_ipv4_3)),
+    CPPUNIT_ASSERT_THROW((void)parse_link_layer(DLT_LINUX_SLL,
+                                                std::begin(lcc_ipv4_3),
+                                                std::end(lcc_ipv4_3)),
                          std::length_error);
   }
 
   void test_parse_lcc_ipv4_too_short() {
-    CPPUNIT_ASSERT_THROW(parse_link_layer(DLT_LINUX_SLL, std::begin(lcc_ipv4_0),
-                                          std::end(lcc_ipv4_0) - 1),
+    CPPUNIT_ASSERT_THROW((void)parse_link_layer(DLT_LINUX_SLL,
+                                                std::begin(lcc_ipv4_0),
+                                                std::end(lcc_ipv4_0) - 1),
                          std::length_error);
   }
 
@@ -159,16 +162,16 @@ public:
   }
 
   void test_parse_ethernet_ipv4_too_short() {
-    CPPUNIT_ASSERT_THROW(parse_link_layer(DLT_EN10MB,
-                                          std::begin(ethernet_ipv4_0),
-                                          std::end(ethernet_ipv4_0) - 1),
+    CPPUNIT_ASSERT_THROW((void)parse_link_layer(DLT_EN10MB,
+                                                std::begin(ethernet_ipv4_0),
+                                                std::end(ethernet_ipv4_0) - 1),
                          std::length_error);
   }
 
   void test_parse_ethernet_ipv6_too_short() {
-    CPPUNIT_ASSERT_THROW(parse_link_layer(DLT_EN10MB,
-                                          std::begin(ethernet_ipv6_0),
-                                          std::end(ethernet_ipv6_0) - 1),
+    CPPUNIT_ASSERT_THROW((void)parse_link_layer(DLT_EN10MB,
+                                                std::begin(ethernet_ipv6_0),
+                                                std::end(ethernet_ipv6_0) - 1),
                          std::length_error);
   }
 
@@ -185,14 +188,16 @@ public:
   }
 
   void test_parse_vlan_ipv4_too_short() {
-    CPPUNIT_ASSERT_THROW(parse_link_layer(ETHERTYPE_VLAN, std::begin(vlan_ipv4),
-                                          std::end(vlan_ipv4) - 1),
+    CPPUNIT_ASSERT_THROW((void)parse_link_layer(ETHERTYPE_VLAN,
+                                                std::begin(vlan_ipv4),
+                                                std::end(vlan_ipv4) - 1),
                          std::length_error);
   }
 
   void test_parse_vlan_ipv6_too_short() {
-    CPPUNIT_ASSERT_THROW(parse_link_layer(ETHERTYPE_VLAN, std::begin(vlan_ipv6),
-                                          std::end(vlan_ipv6) - 1),
+    CPPUNIT_ASSERT_THROW((void)parse_link_layer(ETHERTYPE_VLAN,
+                                                std::begin(vlan_ipv6),
+                                                std::end(vlan_ipv6) - 1),
                          std::length_error);
   }
 
@@ -280,11 +285,15 @@ public:
     CPPUNIT_ASSERT(std::equal(std::begin(expected_mac), std::end(expected_mac),
                               std::begin(binary1.ether_addr_octet)));
 
-    CPPUNIT_ASSERT_THROW(mac_to_binary("0011aacd6543"), std::runtime_error);
-    CPPUNIT_ASSERT_THROW(mac_to_binary("011AaCd6543"), std::runtime_error);
-    CPPUNIT_ASSERT_THROW(mac_to_binary("0:11::Cd:05:43"), std::runtime_error);
-    CPPUNIT_ASSERT_THROW(mac_to_binary("0:11::Cd:5:43"), std::runtime_error);
-    CPPUNIT_ASSERT_THROW(mac_to_binary("fdsafdsa"), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)mac_to_binary("0011aacd6543"),
+                         std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)mac_to_binary("011AaCd6543"),
+                         std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)mac_to_binary("0:11::Cd:05:43"),
+                         std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)mac_to_binary("0:11::Cd:5:43"),
+                         std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)mac_to_binary("fdsafdsa"), std::runtime_error);
   }
 
   static void test_binary_to_mac() {

--- a/tests/file_descriptor_test.cpp
+++ b/tests/file_descriptor_test.cpp
@@ -62,7 +62,7 @@ public:
     CPPUNIT_ASSERT(!file_exists(filename));
   }
 
-  int open_file() const {
+  [[nodiscard]] int open_file() const {
     return open(filename.c_str(), O_CREAT | O_RDWR,
                 S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
   }
@@ -188,7 +188,7 @@ public:
   static void test_fd_read() {
     File_descriptor fd;
     fd.fd = std::numeric_limits<int>::max();
-    CPPUNIT_ASSERT_THROW(fd.read(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)fd.read(), std::runtime_error);
     fd.fd = -1;
   }
 
@@ -225,9 +225,9 @@ public:
              0,       {0},     nullptr, 0,       nullptr, nullptr,
              nullptr, nullptr, 0,       0,       {0}};
     bla._fileno = -1;
-    CPPUNIT_ASSERT_THROW(get_fd_from_stream(&bla), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)get_fd_from_stream(&bla), std::runtime_error);
 
-    CPPUNIT_ASSERT_THROW(get_fd_from_stream(nullptr), std::domain_error);
+    CPPUNIT_ASSERT_THROW((void)get_fd_from_stream(nullptr), std::domain_error);
   }
 
   static void test_duplicate_file_descriptors() {

--- a/tests/int_utils_test.cpp
+++ b/tests/int_utils_test.cpp
@@ -40,19 +40,22 @@ public:
                          str_to_integral<unsigned int>("9001"));
   }
 
-  static void outofnegbounds() { str_to_integral<unsigned int>("-1"); }
+  static void outofnegbounds() { (void)str_to_integral<unsigned int>("-1"); }
 
-  static void outofposbounds() { str_to_integral<uint8_t>("256"); }
+  static void outofposbounds() { (void)str_to_integral<uint8_t>("256"); }
 
   static void test_stoll() {
     CPPUNIT_ASSERT_EQUAL(static_cast<int64_t>(123), stoll_with_checks("123"));
     CPPUNIT_ASSERT_EQUAL(static_cast<int64_t>(-123), stoll_with_checks("-123"));
     CPPUNIT_ASSERT_EQUAL(static_cast<int64_t>(0), stoll_with_checks("0"));
-    CPPUNIT_ASSERT_THROW(stoll_with_checks("1234567890123456789123456789"),
-                         std::out_of_range);
-    CPPUNIT_ASSERT_THROW(stoll_with_checks("-1234567890123456789123456789"),
-                         std::out_of_range);
-    CPPUNIT_ASSERT_THROW(stoll_with_checks("fdasfd"), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(
+        (void)stoll_with_checks("1234567890123456789123456789"),
+        std::out_of_range);
+    CPPUNIT_ASSERT_THROW(
+        (void)stoll_with_checks("-1234567890123456789123456789"),
+        std::out_of_range);
+    CPPUNIT_ASSERT_THROW((void)stoll_with_checks("fdasfd"),
+                         std::invalid_argument);
 
     CPPUNIT_ASSERT_EQUAL(static_cast<int64_t>(0), stoll_with_checks("0", 16));
     CPPUNIT_ASSERT_EQUAL(static_cast<int64_t>(10), stoll_with_checks("a", 16));
@@ -62,10 +65,12 @@ public:
   static void test_stoull() {
     CPPUNIT_ASSERT_EQUAL(static_cast<uint64_t>(123), stoull_with_checks("123"));
     CPPUNIT_ASSERT_EQUAL(static_cast<uint64_t>(0), stoull_with_checks("0"));
-    CPPUNIT_ASSERT_THROW(stoull_with_checks("-123"), std::out_of_range);
-    CPPUNIT_ASSERT_THROW(stoull_with_checks("12345678901234567890123456789"),
-                         std::out_of_range);
-    CPPUNIT_ASSERT_THROW(stoull_with_checks("fdasfd"), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)stoull_with_checks("-123"), std::out_of_range);
+    CPPUNIT_ASSERT_THROW(
+        (void)stoull_with_checks("12345678901234567890123456789"),
+        std::out_of_range);
+    CPPUNIT_ASSERT_THROW((void)stoull_with_checks("fdasfd"),
+                         std::invalid_argument);
 
     CPPUNIT_ASSERT_EQUAL(static_cast<uint64_t>(0), stoull_with_checks("0", 16));
     CPPUNIT_ASSERT_EQUAL(static_cast<uint64_t>(10),

--- a/tests/ip_address_test.cpp
+++ b/tests/ip_address_test.cpp
@@ -56,12 +56,13 @@ public:
     compare_ip("fe80::12/34%lo", AF_INET6, "fe80::12", subnet_size_34);
     compare_ip("::1", AF_INET6, "::1", subnet_size_128);
     compare_ip("::1/66", AF_INET6, "::1", subnet_size_66);
-    CPPUNIT_ASSERT_THROW(parse_ip("bla/bla/"), std::invalid_argument);
-    CPPUNIT_ASSERT_THROW(parse_ip("fe80::123::123"), std::runtime_error);
-    CPPUNIT_ASSERT_THROW(parse_ip("10"), std::runtime_error);
-    CPPUNIT_ASSERT_THROW(parse_ip("fe80::123/200"), std::invalid_argument);
-    CPPUNIT_ASSERT_THROW(parse_ip("10.0.0.1/200"), std::invalid_argument);
-    CPPUNIT_ASSERT_THROW(parse_ip(""), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)parse_ip("bla/bla/"), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)parse_ip("fe80::123::123"), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)parse_ip("10"), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)parse_ip("fe80::123/200"),
+                         std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)parse_ip("10.0.0.1/200"), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)parse_ip(""), std::invalid_argument);
   }
 
   static void test_stream_operator() {

--- a/tests/ip_test.cpp
+++ b/tests/ip_test.cpp
@@ -71,9 +71,9 @@ public:
   }
 
   void test_ipv4_tcp_0_too_short() {
-    CPPUNIT_ASSERT_THROW(
-        parse_ip(ip::ipv4, std::begin(ipv4_tcp_0), std::end(ipv4_tcp_0) - 1),
-        std::length_error);
+    CPPUNIT_ASSERT_THROW((void)parse_ip(ip::ipv4, std::begin(ipv4_tcp_0),
+                                        std::end(ipv4_tcp_0) - 1),
+                         std::length_error);
   }
 
   void test_ipv4_tcp_1() {
@@ -83,9 +83,9 @@ public:
   }
 
   void test_ipv4_tcp_1_too_short() {
-    CPPUNIT_ASSERT_THROW(
-        parse_ip(ip::ipv4, std::begin(ipv4_tcp_1), std::end(ipv4_tcp_1) - 1),
-        std::length_error);
+    CPPUNIT_ASSERT_THROW((void)parse_ip(ip::ipv4, std::begin(ipv4_tcp_1),
+                                        std::end(ipv4_tcp_1) - 1),
+                         std::length_error);
   }
 
   void test_ipv4_udp() {
@@ -109,7 +109,7 @@ public:
 
   void test_ipv6_udp_too_short() {
     CPPUNIT_ASSERT_THROW(
-        parse_ip(ip::ipv6, std::begin(ipv6_udp), std::end(ipv6_udp) - 1),
+        (void)parse_ip(ip::ipv6, std::begin(ipv6_udp), std::end(ipv6_udp) - 1),
         std::length_error);
   }
 

--- a/tests/ip_utils_test.cpp
+++ b/tests/ip_utils_test.cpp
@@ -56,7 +56,7 @@ public:
         parse_items(std::vector<std::string>(), str_to_integral<int>).empty());
 
     CPPUNIT_ASSERT_THROW(
-        parse_items(std::vector<std::string>{""}, str_to_integral<int>),
+        (void)parse_items(std::vector<std::string>{""}, str_to_integral<int>),
         std::invalid_argument);
   }
 };

--- a/tests/packet_parser_test.cpp
+++ b/tests/packet_parser_test.cpp
@@ -104,14 +104,14 @@ public:
   void test_parse_ethernet_ipv4_tcp_too_short() {
     std::vector<uint8_t> ethernet_ipv4_tcp_short(
         std::begin(ethernet_ipv4_tcp), std::end(ethernet_ipv4_tcp) - 1);
-    CPPUNIT_ASSERT_THROW(get_headers(DLT_EN10MB, ethernet_ipv4_tcp_short),
+    CPPUNIT_ASSERT_THROW((void)get_headers(DLT_EN10MB, ethernet_ipv4_tcp_short),
                          std::length_error);
   }
 
   void test_parse_ethernet_ipv6_tcp_too_short() {
     std::vector<uint8_t> ethernet_ipv6_tcp_short(
         std::begin(ethernet_ipv6_tcp), std::end(ethernet_ipv6_tcp) - 1);
-    CPPUNIT_ASSERT_THROW(get_headers(DLT_EN10MB, ethernet_ipv6_tcp_short),
+    CPPUNIT_ASSERT_THROW((void)get_headers(DLT_EN10MB, ethernet_ipv6_tcp_short),
                          std::length_error);
   }
 
@@ -136,14 +136,14 @@ public:
   void test_parse_lcc_ipv4_udp_too_short() {
     std::vector<uint8_t> lcc_ipv4_udp_short(std::begin(lcc_ipv4_udp),
                                             std::end(lcc_ipv4_udp) - 1);
-    CPPUNIT_ASSERT_THROW(get_headers(DLT_LINUX_SLL, lcc_ipv4_udp_short),
+    CPPUNIT_ASSERT_THROW((void)get_headers(DLT_LINUX_SLL, lcc_ipv4_udp_short),
                          std::length_error);
   }
 
   void test_parse_lcc_ipv6_tcp_too_short() {
     std::vector<uint8_t> lcc_ipv6_tcp_short(std::begin(lcc_ipv6_tcp),
                                             std::end(lcc_ipv6_tcp) - 1);
-    CPPUNIT_ASSERT_THROW(get_headers(DLT_LINUX_SLL, lcc_ipv6_tcp_short),
+    CPPUNIT_ASSERT_THROW((void)get_headers(DLT_LINUX_SLL, lcc_ipv6_tcp_short),
                          std::length_error);
   }
 
@@ -160,8 +160,9 @@ public:
   void test_parse_lcc_vlan_ipv4_udp_too_short() {
     std::vector<uint8_t> lcc_vlan_ipv4_udp_short(
         std::begin(lcc_vlan_ipv4_udp), std::end(lcc_vlan_ipv4_udp) - 1);
-    CPPUNIT_ASSERT_THROW(get_headers(DLT_LINUX_SLL, lcc_vlan_ipv4_udp_short),
-                         std::length_error);
+    CPPUNIT_ASSERT_THROW(
+        (void)get_headers(DLT_LINUX_SLL, lcc_vlan_ipv4_udp_short),
+        std::length_error);
   }
 
   static void test_parse_unknown_link_layer() {

--- a/tests/scope_guard_test.cpp
+++ b/tests/scope_guard_test.cpp
@@ -145,7 +145,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(ints, guard.cont);
     CPPUNIT_ASSERT_EQUAL(x, guard.ref);
 
-    CPPUNIT_ASSERT_THROW(guard(Action::del), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)guard(Action::del), std::runtime_error);
   }
 
   static void test_temp_ip() {

--- a/tests/socket_test.cpp
+++ b/tests/socket_test.cpp
@@ -54,7 +54,8 @@ struct Socket_listen : public Socket {
     return data;
   }
 
-  template <typename Optval> Optval get_sock_opt(int level, int optname) const {
+  template <typename Optval>
+  [[nodiscard]] Optval get_sock_opt(int level, int optname) const {
     Optval optval;
     socklen_t optlen = sizeof(Optval);
     const int ret_val = getsockopt(fd(), level, optname, &optval, &optlen);
@@ -147,7 +148,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(std::string("0:0:0:0:0:0"), binary_to_mac(ea));
 
     CPPUNIT_ASSERT(1 < s0.get_ifindex("enp0s25"));
-    CPPUNIT_ASSERT_THROW(s0.get_ifindex("eth0"), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)s0.get_ifindex("eth0"), std::runtime_error);
   }
 
   static void test_set_sock_opt() {

--- a/tests/spawn_process_test.cpp
+++ b/tests/spawn_process_test.cpp
@@ -38,7 +38,7 @@ public:
 
   static void test_wait_until_pid_exits() {
     pid_t pid = -1;
-    CPPUNIT_ASSERT_THROW(wait_until_pid_exits(pid), std::runtime_error);
+    CPPUNIT_ASSERT_THROW((void)wait_until_pid_exits(pid), std::runtime_error);
   }
 
   static void test_without_exceptions() {

--- a/tests/wol_test.cpp
+++ b/tests/wol_test.cpp
@@ -71,8 +71,9 @@ public:
   }
 
   static void test_parse_invalid_wol_method() {
-    CPPUNIT_ASSERT_THROW(parse_wol_method("unknown"), std::invalid_argument);
-    CPPUNIT_ASSERT_THROW(parse_wol_method(""), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)parse_wol_method("unknown"),
+                         std::invalid_argument);
+    CPPUNIT_ASSERT_THROW((void)parse_wol_method(""), std::invalid_argument);
   }
 
   static void test_ostream_operator() {


### PR DESCRIPTION
Warnings have to be kept 0.