### PR TITLE
Potential fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clang-format-tidy.yml
+++ b/.github/workflows/clang-format-tidy.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   cpp-linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -60,6 +60,8 @@ jobs:
         lcov-file: ${{github.workspace}}/build/meson-logs/coverage.info
 
   fsanitize:
+    permissions:
+      contents: read
     strategy:
       matrix:
         sanitizer: ['address,undefined', 'thread']

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -11,6 +11,9 @@ jobs:
   min-build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
     - uses: actions/checkout@v4
 
@@ -60,12 +63,15 @@ jobs:
         lcov-file: ${{github.workspace}}/build/meson-logs/coverage.info
 
   fsanitize:
-    permissions:
-      contents: read
     strategy:
       matrix:
         sanitizer: ['address,undefined', 'thread']
+
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
       pull-requests: write
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/lurtz/sleep-proxy/security/code-scanning/3](https://github.com/lurtz/sleep-proxy/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `fsanitize` job in the workflow file. This block should specify the least privilege required for the job, which in this case is `contents: read`. This ensures that the GITHUB_TOKEN used by the job has restricted access, reducing the risk of unintended actions.

The changes will be made to the `.github/workflows/meson.yml` file by adding the `permissions` key under the `fsanitize` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
