### PR TITLE
Remove obsolete option from clang-tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,7 +26,6 @@ Checks:          'clang-diagnostic-*,
                   -cppcoreguidelines-avoid-const-or-ref-data-members'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 User:            lutz
 CheckOptions:


### PR DESCRIPTION
With this option running clang-tidy on Debian Trixie does not work. Removing it fixed it.