### PR TITLE
clang-tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,9 +23,9 @@ Checks:          'clang-diagnostic-*,
                   # triggered when using structs defined by C / POSIX,
                   -cppcoreguidelines-pro-type-union-access,
                   # too many code atm,
-                  -cppcoreguidelines-avoid-const-or-ref-data-members',
+                  -cppcoreguidelines-avoid-const-or-ref-data-members,
                   # Its automatic fix broke at least one test. I am afraid it might break more,
-                  -performance-avoid-endl
+                  -performance-avoid-endl'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 FormatStyle:     none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,9 @@ Checks:          'clang-diagnostic-*,
                   # triggered when using structs defined by C / POSIX,
                   -cppcoreguidelines-pro-type-union-access,
                   # too many code atm,
-                  -cppcoreguidelines-avoid-const-or-ref-data-members'
+                  -cppcoreguidelines-avoid-const-or-ref-data-members',
+                  # Its automatic fix broke at least one test. I am afraid it might break more,
+                  -performance-avoid-endl
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 FormatStyle:     none

--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+#find * -name "*.h" -or -name "*.cpp" | xargs clang-tidy -p build --fix --fix-notes
 find * -name "*.h" -or -name "*.cpp" | xargs clang-tidy -p build
 
 exit 0

--- a/src/include/args.h
+++ b/src/include/args.h
@@ -32,7 +32,7 @@ void print_help();
  */
 struct Host_args {
   /** the interface to use */
-  std::string interface {};
+  std::string interface{};
   /** addresses to listen on */
   std::vector<IP_address> address{};
   /** ports to listen on */
@@ -49,12 +49,9 @@ struct Host_args {
             std::vector<uint16_t> ports_, ether_addr mac_,
             std::string hostname_, unsigned int ping_tries_,
             Wol_method wol_method_)
-      : interface {
-    std::move(interface_)
-  }, address{std::move(address_)}, ports{std::move(ports_)}, mac{mac_},
-      hostname{std::move(hostname_)}, ping_tries{ping_tries_},
-      wol_method{wol_method_} {
-  }
+      : interface{std::move(interface_)}, address{std::move(address_)},
+        ports{std::move(ports_)}, mac{mac_}, hostname{std::move(hostname_)},
+        ping_tries{ping_tries_}, wol_method{wol_method_} {}
 };
 
 struct Args {

--- a/src/include/container_utils.h
+++ b/src/include/container_utils.h
@@ -28,8 +28,8 @@ template <typename T> [[nodiscard]] T identity(const T &t) { return t; }
 
 template <typename Container, typename Func>
 [[nodiscard]] std::string join(Container c, Func fun, const std::string &sep) {
-  using input_type = typename std::result_of<decltype(fun)(
-      typename Container::value_type)>::type;
+  using input_type =
+      std::result_of_t<decltype(fun)(typename Container::value_type)>;
   std::stringstream ss;
   std::ostream_iterator<input_type> iter(ss, sep.c_str());
   if (std::begin(c) != std::end(c)) {
@@ -49,7 +49,7 @@ operator+(std::vector<T, Alloc> &&lhs, const std::vector<T, Alloc> &rhs) {
 
 template <typename iterator>
 void check_type_and_range(iterator data, iterator end, size_t const min_size) {
-  static_assert(std::is_same<typename iterator::value_type, uint8_t>::value,
+  static_assert(std::is_same_v<typename iterator::value_type, uint8_t>,
                 "container has to carry u_char or uint8_t");
   if (data >= end || static_cast<size_t>(std::distance(data, end)) < min_size) {
     throw std::length_error("not enough data");

--- a/src/include/duplicate_address_watcher.h
+++ b/src/include/duplicate_address_watcher.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "file_descriptor.h"
 #include "ip_address.h"
 #include "pcap_wrapper.h"
 #include "scope_guard.h"

--- a/src/include/int_utils.h
+++ b/src/include/int_utils.h
@@ -31,7 +31,7 @@ static int const base_10 = 10;
 /** range check for signed target types */
 template <typename R, typename T>
 [[nodiscard]] bool within_bounds(const T &val) noexcept
-  requires std::is_signed<T>::value
+  requires std::is_signed_v<T>
 {
   return std::numeric_limits<R>::lowest() <= val &&
          val <= std::numeric_limits<R>::max();
@@ -40,7 +40,7 @@ template <typename R, typename T>
 /** range check for unsigned target types */
 template <typename R, typename T>
 [[nodiscard]] bool within_bounds(const T &val) noexcept
-  requires std::is_unsigned<T>::value
+  requires std::is_unsigned_v<T>
 {
   return val <= std::numeric_limits<R>::max();
 }
@@ -48,7 +48,7 @@ template <typename R, typename T>
 /** convert to signed types */
 template <typename T>
 [[nodiscard]] int64_t str_to_integral_helper(const std::string &string)
-  requires std::is_signed<T>::value
+  requires std::is_signed_v<T>
 {
   return stoll_with_checks(string);
 }
@@ -56,7 +56,7 @@ template <typename T>
 /** convert to unsigned types */
 template <typename T>
 [[nodiscard]] uint64_t str_to_integral_helper(const std::string &string)
-  requires std::is_unsigned<T>::value
+  requires std::is_unsigned_v<T>
 {
   return stoull_with_checks(string);
 }

--- a/src/include/int_utils.h
+++ b/src/include/int_utils.h
@@ -22,38 +22,42 @@
 #include <stdexcept>
 #include <string>
 
-static auto const base_10 = int{10};
+static int const base_10 = 10;
 [[nodiscard]] int64_t stoll_with_checks(const std::string &s,
                                         int base = base_10);
 [[nodiscard]] uint64_t stoull_with_checks(const std::string &s,
                                           int base = base_10);
 
 /** range check for signed target types */
-template <typename R, typename T,
-          typename std::enable_if<std::is_signed<T>::value>::type * = nullptr>
-[[nodiscard]] bool within_bounds(const T &val) noexcept {
+template <typename R, typename T>
+[[nodiscard]] bool within_bounds(const T &val) noexcept
+  requires std::is_signed<T>::value
+{
   return std::numeric_limits<R>::lowest() <= val &&
          val <= std::numeric_limits<R>::max();
 }
 
 /** range check for unsigned target types */
-template <typename R, typename T,
-          typename std::enable_if<std::is_unsigned<T>::value>::type * = nullptr>
-[[nodiscard]] bool within_bounds(const T &val) noexcept {
+template <typename R, typename T>
+[[nodiscard]] bool within_bounds(const T &val) noexcept
+  requires std::is_unsigned<T>::value
+{
   return val <= std::numeric_limits<R>::max();
 }
 
 /** convert to signed types */
-template <typename T,
-          typename std::enable_if<std::is_signed<T>::value>::type * = nullptr>
-[[nodiscard]] int64_t str_to_integral_helper(const std::string &string) {
+template <typename T>
+[[nodiscard]] int64_t str_to_integral_helper(const std::string &string)
+  requires std::is_signed<T>::value
+{
   return stoll_with_checks(string);
 }
 
 /** convert to unsigned types */
-template <typename T,
-          typename std::enable_if<std::is_unsigned<T>::value>::type * = nullptr>
-[[nodiscard]] uint64_t str_to_integral_helper(const std::string &string) {
+template <typename T>
+[[nodiscard]] uint64_t str_to_integral_helper(const std::string &string)
+  requires std::is_unsigned<T>::value
+{
   return stoull_with_checks(string);
 }
 

--- a/src/include/ip.h
+++ b/src/include/ip.h
@@ -66,7 +66,7 @@ std::ostream &operator<<(std::ostream &out, const ip &ip);
 template <typename iterator>
 [[nodiscard]] bool
 ethernet_payload_and_ip_version_dont_match(uint16_t const type, iterator data) {
-  static_assert(std::is_same<typename iterator::value_type, uint8_t>::value,
+  static_assert(std::is_same_v<typename iterator::value_type, uint8_t>,
                 "container has to carry u_char or uint8_t");
 
   auto const version = static_cast<uint8_t>(*data >> 4);
@@ -97,9 +97,11 @@ template <typename iterator>
   std::copy(data, data + ip::ipv4_address_size_byte,
             reinterpret_cast<uint8_t *>(&ip_dst));
   static auto const no_subnet = uint8_t{32};
-  return std::make_unique<ip>(ip::ipv4, header_length,
-                              IP_address{AF_INET, {ip_src}, no_subnet},
-                              IP_address{AF_INET, {ip_dst}, no_subnet}, ip_p);
+  return std::make_unique<ip>(
+      ip::ipv4, header_length,
+      IP_address{.family = AF_INET, .address = {ip_src}, .subnet = no_subnet},
+      IP_address{.family = AF_INET, .address = {ip_dst}, .subnet = no_subnet},
+      ip_p);
 }
 
 template <typename iterator>

--- a/src/include/ip.h
+++ b/src/include/ip.h
@@ -32,8 +32,8 @@ struct ip {
   constexpr static auto ipv4_address_size_byte = uint8_t{4};
   constexpr static auto ipv6_address_size_byte = uint8_t{16};
 
-  enum Version { ipv4 = ETHERTYPE_IP, ipv6 = ETHERTYPE_IPV6 };
-  enum Payload { TCP = IPPROTO_TCP, UDP = IPPROTO_UDP };
+  enum Version : std::uint16_t { ipv4 = ETHERTYPE_IP, ipv6 = ETHERTYPE_IPV6 };
+  enum Payload : std::uint8_t { TCP = IPPROTO_TCP, UDP = IPPROTO_UDP };
 
   ip::Version m_version;
   size_t m_header_length;

--- a/src/include/ip.h
+++ b/src/include/ip.h
@@ -91,10 +91,12 @@ template <typename iterator>
   std::advance(data, 3);
   struct in_addr ip_src{};
   std::copy(data, data + ip::ipv4_address_size_byte,
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             reinterpret_cast<uint8_t *>(&ip_src));
   std::advance(data, ip::ipv4_address_size_byte);
   struct in_addr ip_dst{};
   std::copy(data, data + ip::ipv4_address_size_byte,
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             reinterpret_cast<uint8_t *>(&ip_dst));
   static auto const no_subnet = uint8_t{32};
   return std::make_unique<ip>(

--- a/src/include/ip_utils.h
+++ b/src/include/ip_utils.h
@@ -26,8 +26,9 @@ static const std::string iface_chars{"qwertzuiopasdfghjklyxcvbnm.-0123456789"};
 std::string validate_iface(std::string const &iface);
 
 template <typename Container, typename Func>
-[[nodiscard]] auto parse_items(Container &&items, Func &&parser) -> std::vector<
-    typename std::invoke_result_t<decltype(parser), const std::string &>> {
+[[nodiscard]] auto parse_items(Container const &items, Func &&parser)
+    -> std::vector<
+        typename std::invoke_result_t<decltype(parser), const std::string &>> {
   static_assert(std::is_same_v<typename std::decay<Container>::type::value_type,
                                std::string>,
                 "container has to carry std::string");

--- a/src/include/ip_utils.h
+++ b/src/include/ip_utils.h
@@ -29,8 +29,8 @@ std::string validate_iface(std::string const &iface);
 template <typename Container, typename Func>
 [[nodiscard]] auto parse_items(Container &&items, Func &&parser) -> std::vector<
     typename std::invoke_result_t<decltype(parser), const std::string &>> {
-  static_assert(std::is_same<typename std::decay<Container>::type::value_type,
-                             std::string>::value,
+  static_assert(std::is_same_v<typename std::decay<Container>::type::value_type,
+                               std::string>,
                 "container has to carry std::string");
   std::vector<
       typename std::invoke_result_t<decltype(parser), const std::string &>>

--- a/src/include/ip_utils.h
+++ b/src/include/ip_utils.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <algorithm>
-#include <functional>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/src/include/libsleep_proxy.h
+++ b/src/include/libsleep_proxy.h
@@ -37,7 +37,7 @@ rule_to_listen_on_ips_and_ports(const std::vector<IP_address> &ips,
 [[nodiscard]] bool ping_and_wait(const std::string &iface, const IP_address &ip,
                                  unsigned int tries);
 
-enum class Emulate_host_status {
+enum class Emulate_host_status : std::uint8_t {
   success,
   wake_failure,
   signal_received,

--- a/src/include/libsleep_proxy.h
+++ b/src/include/libsleep_proxy.h
@@ -19,7 +19,6 @@
 #include "args.h"
 #include "ip_address.h"
 #include <cstdint>
-#include <exception>
 #include <string>
 
 void setup_signals();

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -27,10 +27,10 @@ void log(int priority, const char *format, ...)
 
 void log_string(int priority, char const *t);
 
-template <typename T> void log_string(int priority, T &&t);
+template <typename T> void log_string(int priority, T const &t);
 
-template <> void log_string<std::string>(int priority, std::string &&t);
+template <> void log_string<std::string>(int priority, std::string const &t);
 
-template <typename T> void log_string(const int priority, T &&t) {
-  log_string(priority, to_string(std::forward<T>(t)));
+template <typename T> void log_string(const int priority, T const &t) {
+  log_string(priority, to_string(t));
 }

--- a/src/include/pcap_wrapper.h
+++ b/src/include/pcap_wrapper.h
@@ -51,8 +51,8 @@ protected:
   [[nodiscard]] Loop_end_reason get_end_reason() const;
 
 public:
-  static auto const default_snaplen = int{65000};
-  static auto const default_timeout = int{1000};
+  static int const default_snaplen = 65000;
+  static int const default_timeout = 1000;
 
   /** open a pcap instance on iface */
   explicit Pcap_wrapper(std::string const &iface, int snaplen = default_snaplen,

--- a/src/include/pcap_wrapper.h
+++ b/src/include/pcap_wrapper.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -27,7 +28,7 @@
 
 /** Provide a nice interface to pcap and close the handle upon an exception */
 struct Pcap_wrapper {
-  enum class Loop_end_reason {
+  enum class Loop_end_reason : std::uint8_t {
     unset,
     packets_captured,
     signal,

--- a/src/include/scope_guard.h
+++ b/src/include/scope_guard.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "ip_address.h"
-#include "pcap_wrapper.h"
 #include <algorithm>
 #include <functional>
 #include <memory>

--- a/src/include/scope_guard.h
+++ b/src/include/scope_guard.h
@@ -18,12 +18,13 @@
 
 #include "ip_address.h"
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
 
 /** perform or reverse the modification */
-enum struct Action { add, del };
+enum struct Action : std::uint8_t { add, del };
 
 /**
  * Upon creation consume a resource or perform a modification. Upon deletion
@@ -98,7 +99,7 @@ struct Drop_port {
 
 /** Adds a firewall rule to reject either TCP or UDP packets */
 struct Reject_tp {
-  enum struct TP { TCP, UDP };
+  enum struct TP : std::uint8_t { TCP, UDP };
   const IP_address ip;
   const TP tcp_udp;
 

--- a/src/include/socket.h
+++ b/src/include/socket.h
@@ -59,7 +59,7 @@ public:
    * set socket option
    */
   template <typename Optval>
-  void set_sock_opt(int level, int optname, Optval &&optval) {
+  void set_sock_opt(int level, int optname, Optval const &optval) {
     if (setsockopt(sock, level, optname, &optval, sizeof(Optval)) == -1) {
       throw std::runtime_error(std::string("setsockopt() failed: ") +
                                strerror(errno));
@@ -71,7 +71,7 @@ public:
    */
   template <typename Sockaddr>
   ssize_t send_to(const std::vector<uint8_t> &buf, int flags,
-                  Sockaddr &&sockaddr) {
+                  Sockaddr const &sockaddr) {
     ssize_t sent_bytes = sendto(
         sock, buf.data(), buf.size(), flags,
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)

--- a/src/include/spawn_process.h
+++ b/src/include/spawn_process.h
@@ -29,7 +29,8 @@
                                     File_descriptor const &out);
 
 template <typename Container>
-uint8_t spawn(Container &&cmd, File_descriptor const &in = File_descriptor(),
+uint8_t spawn(Container const &cmd,
+              File_descriptor const &in = File_descriptor(),
               File_descriptor const &out = File_descriptor()) {
   static_assert(std::is_same_v<typename std::decay<Container>::type::value_type,
                                std::string>,

--- a/src/include/spawn_process.h
+++ b/src/include/spawn_process.h
@@ -31,8 +31,8 @@
 template <typename Container>
 uint8_t spawn(Container &&cmd, File_descriptor const &in = File_descriptor(),
               File_descriptor const &out = File_descriptor()) {
-  static_assert(std::is_same<typename std::decay<Container>::type::value_type,
-                             std::string>::value,
+  static_assert(std::is_same_v<typename std::decay<Container>::type::value_type,
+                               std::string>,
                 "container has to carry std::string");
 
   // get char * of each string

--- a/src/include/to_string.h
+++ b/src/include/to_string.h
@@ -38,7 +38,7 @@ std::ostream &operator<<(std::ostream &out, std::vector<T, Alloc> v) {
 
 [[nodiscard]] std::string to_string(char const *t);
 
-template <typename T> [[nodiscard]] std::string to_string(T &&t) {
+template <typename T> [[nodiscard]] std::string to_string(T const &t) {
   std::stringstream ss;
   ss << t;
   return ss.str();
@@ -54,7 +54,7 @@ std::string test_characters(const std::string &input,
 
 template <typename Container>
 [[nodiscard]] std::vector<std::vector<std::string::value_type>>
-to_vector_strings(Container &&cont) {
+to_vector_strings(Container const &cont) {
   auto const conv = [](std::string const &s) {
     auto result =
         std::vector<std::string::value_type>(std::begin(s), std::end(s));

--- a/src/include/to_string.h
+++ b/src/include/to_string.h
@@ -71,8 +71,8 @@ to_vector_strings(Container &&cont) {
 
 template <typename Container>
 [[nodiscard]] std::vector<char *> get_c_string_array(Container &cont) {
-  static_assert(std::is_same<typename std::decay<Container>::type::value_type,
-                             std::vector<std::string::value_type>>::value,
+  static_assert(std::is_same_v<typename std::decay<Container>::type::value_type,
+                               std::vector<std::string::value_type>>,
                 "container has to carry std::vector<std::string::value_type>");
   std::vector<std::string::value_type *> ch_ptr;
   ch_ptr.reserve(cont.size());

--- a/src/include/wol.h
+++ b/src/include/wol.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-enum class Wol_method { ethernet, udp };
+enum class Wol_method : std::uint8_t { ethernet, udp };
 
 /**
  * create the payload for a UDP wol packet to be broadcast in to the network

--- a/src/sleep-proxy/args.cpp
+++ b/src/sleep-proxy/args.cpp
@@ -141,10 +141,13 @@ Host_args parse_host_args(const std::string &interface_,
 Args read_commandline(std::span<char *> const &args) {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
   static const option long_options[] = {
-      {"help", no_argument, nullptr, 'h'},
-      {"config", required_argument, nullptr, 'c'},
-      {"syslog", no_argument, nullptr, 's'},
-      {nullptr, 0, nullptr, 0}};
+      {.name = "help", .has_arg = no_argument, .flag = nullptr, .val = 'h'},
+      {.name = "config",
+       .has_arg = required_argument,
+       .flag = nullptr,
+       .val = 'c'},
+      {.name = "syslog", .has_arg = no_argument, .flag = nullptr, .val = 's'},
+      {.name = nullptr, .has_arg = 0, .flag = nullptr, .val = 0}};
   int option_index = 0;
   int c = -1;
   std::vector<Host_args> ret_val;
@@ -176,7 +179,7 @@ Args read_commandline(std::span<char *> const &args) {
       break;
     }
   }
-  return {std::move(ret_val), to_syslog};
+  return {.host_args = std::move(ret_val), .syslog = to_syslog};
 }
 
 std::ostream &operator<<(std::ostream &out, const Host_args &args) {

--- a/src/sleep-proxy/duplicate_address_watcher.cpp
+++ b/src/sleep-proxy/duplicate_address_watcher.cpp
@@ -18,6 +18,7 @@
 #include "container_utils.h"
 #include "log.h"
 #include "spawn_process.h"
+#include <algorithm>
 #include <cctype>
 
 namespace {
@@ -33,7 +34,7 @@ std::vector<std::string> get_cmd_ipv6() {
 bool contains_mac_different_from_given(std::string mac,
                                        std::vector<std::string> const &lines) {
   auto const transform_to_upper = [](std::string tmp) {
-    std::transform(std::begin(tmp), std::end(tmp), std::begin(tmp), ::toupper);
+    std::ranges::transform(tmp, std::begin(tmp), ::toupper);
     return tmp;
   };
 
@@ -43,7 +44,7 @@ bool contains_mac_different_from_given(std::string mac,
 
   mac = transform_to_upper(mac);
 
-  return std::any_of(std::begin(lines), std::end(lines), macs_are_not_equal);
+  return std::ranges::any_of(lines, macs_are_not_equal);
 }
 
 std::string get_mac(std::string const &iface) {
@@ -152,16 +153,15 @@ void daw_thread_main_ipv6(const std::string &iface, const IP_address &ip,
 Duplicate_address_watcher::Duplicate_address_watcher(std::string ifacee,
                                                      const IP_address ipp,
                                                      Pcap_wrapper &pc)
-    : iface(std::move(ifacee)), ip(ipp),
-      pcap(pc), is_ip_occupied{Ip_neigh_checker{get_mac(iface)}},
-      watcher(), loop{false} {}
+    : iface(std::move(ifacee)), ip(ipp), pcap(pc),
+      is_ip_occupied{Ip_neigh_checker{get_mac(iface)}}, watcher(), loop{false} {
+}
 
 Duplicate_address_watcher::Duplicate_address_watcher(
     std::string ifacee, const IP_address ipp, Pcap_wrapper &pc,
     Is_ip_occupied is_ip_occupiedd)
-    : iface(std::move(ifacee)), ip(ipp),
-      pcap(pc), is_ip_occupied{std::move(is_ip_occupiedd)},
-      watcher(), loop{false} {}
+    : iface(std::move(ifacee)), ip(ipp), pcap(pc),
+      is_ip_occupied{std::move(is_ip_occupiedd)}, watcher(), loop{false} {}
 
 Duplicate_address_watcher::~Duplicate_address_watcher() { stop_watcher(); }
 

--- a/src/sleep-proxy/ethernet.cpp
+++ b/src/sleep-proxy/ethernet.cpp
@@ -15,7 +15,6 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "ethernet.h"
-#include "int_utils.h"
 #include <iterator>
 #include <stdexcept>
 

--- a/src/sleep-proxy/file_descriptor.cpp
+++ b/src/sleep-proxy/file_descriptor.cpp
@@ -80,7 +80,7 @@ File_descriptor::~File_descriptor() {
     close();
   } catch (std::exception const &e) {
     std::cerr << "File_descriptor::~File_descriptor(): caught exception: "
-              << e.what() << '\n';
+              << e.what() << std::endl;
   }
 }
 

--- a/src/sleep-proxy/file_descriptor.cpp
+++ b/src/sleep-proxy/file_descriptor.cpp
@@ -16,6 +16,7 @@
 
 #include "file_descriptor.h"
 #include "container_utils.h"
+#include <algorithm>
 #include <array>
 #include <cerrno>
 #include <cstring>
@@ -37,13 +38,13 @@ std::vector<std::string>
 byte_vector_to_strings(std::vector<uint8_t> const &data) {
   std::vector<std::vector<uint8_t>> const splitted_data = split(data, '\n');
   std::vector<std::string> lines(splitted_data.size());
-  std::transform(std::begin(splitted_data), std::end(splitted_data),
-                 std::begin(lines), byte_vector_to_string);
+  std::ranges::transform(splitted_data, std::begin(lines),
+                         byte_vector_to_string);
   return lines;
 }
 
 bool is_data_ready_to_read(int const fd) {
-  pollfd fds{fd, POLLIN, 0};
+  pollfd fds{.fd = fd, .events = POLLIN, .revents = 0};
 
   int retval = poll(&fds, 1, 0);
 
@@ -79,7 +80,7 @@ File_descriptor::~File_descriptor() {
     close();
   } catch (std::exception const &e) {
     std::cerr << "File_descriptor::~File_descriptor(): caught exception: "
-              << e.what() << std::endl;
+              << e.what() << '\n';
   }
 }
 
@@ -130,7 +131,7 @@ void flush_file(FILE *const stream) {
 }
 
 bool file_exists(const std::string &filename) {
-  struct stat stats {};
+  struct stat stats{};
   const auto errno_save = errno;
   bool ret_val = stat(filename.c_str(), &stats) == 0;
   errno = errno_save;

--- a/src/sleep-proxy/libsleep_proxy.cpp
+++ b/src/sleep-proxy/libsleep_proxy.cpp
@@ -79,12 +79,12 @@ std::vector<Scope_guard> setup_firewall_and_ips(const Host_args &args) {
     // setup firewall first, some services might respond
     // reject any incoming connection, except the ones to the
     // ports specified
-    guards.emplace_back(Reject_tp{ip, Reject_tp::TP::TCP});
-    guards.emplace_back(Reject_tp{ip, Reject_tp::TP::UDP});
+    guards.emplace_back(Reject_tp{.ip = ip, .tcp_udp = Reject_tp::TP::TCP});
+    guards.emplace_back(Reject_tp{.ip = ip, .tcp_udp = Reject_tp::TP::UDP});
     for (auto const &port : args.ports) {
-      guards.emplace_back(Drop_port{ip, port});
+      guards.emplace_back(Drop_port{.ip = ip, .port = port});
     }
-    guards.emplace_back(Temp_ip{args.interface, ip});
+    guards.emplace_back(Temp_ip{.iface = args.interface, .ip = ip});
   }
   return guards;
 }
@@ -205,7 +205,7 @@ rule_to_listen_on_ips_and_ports(const std::vector<IP_address> &ips,
 }
 
 std::string get_bindable_ip(const std::string &iface, const std::string &ip) {
-  if (ip.find("fe80") == 0) {
+  if (ip.starts_with("fe80")) {
     return ip + '%' + iface;
   }
   return ip;

--- a/src/sleep-proxy/libsleep_proxy.cpp
+++ b/src/sleep-proxy/libsleep_proxy.cpp
@@ -18,7 +18,6 @@
 #include "args.h"
 #include "container_utils.h"
 #include "duplicate_address_watcher.h"
-#include "ip_utils.h"
 #include "log.h"
 #include "packet_parser.h"
 #include "pcap_wrapper.h"

--- a/src/sleep-proxy/log.cpp
+++ b/src/sleep-proxy/log.cpp
@@ -46,7 +46,8 @@ void setup_log(const std::string &ident, int option, int facility) {
 
 void log_string(int priority, char const *const t) { log(priority, "%s", t); }
 
-template <> void log_string<std::string>(const int priority, std::string &&t) {
+template <>
+void log_string<std::string>(const int priority, std::string const &t) {
   log(priority, "%s", t.c_str());
 }
 

--- a/src/sleep-proxy/log.cpp
+++ b/src/sleep-proxy/log.cpp
@@ -60,6 +60,9 @@ void log(const int priority, const char *format, ...) {
   if (logger == nullptr) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     std::vprintf(format, args);
+    // intention is to use the same library to add \n which was also used to
+    // print the log message
+    // NOLINTNEXTLINE(modernize-use-std-print)
     std::printf("\n");
   } else {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)

--- a/src/sleep-proxy/packet_parser.cpp
+++ b/src/sleep-proxy/packet_parser.cpp
@@ -17,8 +17,10 @@
 #include "packet_parser.h"
 #include "log.h"
 #include <iterator>
+#include <memory>
 
-template <typename T> void print_if_not_nullptr(std::ostream &out, T &&ptr) {
+template <typename T>
+void print_if_not_nullptr(std::ostream &out, std::unique_ptr<T> const &ptr) {
   if (ptr != nullptr) {
     out << *ptr;
   }

--- a/src/sleep-proxy/pcap_wrapper.cpp
+++ b/src/sleep-proxy/pcap_wrapper.cpp
@@ -52,7 +52,7 @@ struct BPF {
   bpf_program bpf;
   BPF(std::unique_ptr<pcap_t, void (*)(pcap_t *)> &pc,
       const std::string &filter)
-      : bpf{0, nullptr} {
+      : bpf{.bf_len = 0, .bf_insns = nullptr} {
     // pcap_compile is not thread safe
     // see http://seclists.org/tcpdump/2012/q2/22
     static std::mutex pcap_compile_mutex;
@@ -137,7 +137,7 @@ void Pcap_wrapper::set_filter(const std::string &filter) {
 
 Pcap_wrapper::Loop_end_reason Pcap_wrapper::loop(const int count,
                                                  Callback_t cb) {
-  auto ret_val = int{1};
+  int ret_val = 1;
   auto loop_f = create_loop(ret_val);
 
   loop_thread = std::thread{loop_f, pc.get(), count, std::move(cb)};

--- a/src/sleep-proxy/scope_guard.cpp
+++ b/src/sleep-proxy/scope_guard.cpp
@@ -17,7 +17,6 @@
 #include "scope_guard.h"
 #include "container_utils.h"
 #include "int_utils.h"
-#include "ip_utils.h"
 #include "log.h"
 #include "spawn_process.h"
 #include "to_string.h"

--- a/src/sleep-proxy/scope_guard.cpp
+++ b/src/sleep-proxy/scope_guard.cpp
@@ -60,7 +60,7 @@ std::string ipv6_to_u32_rule(IP_address const &ip) {
   uint32_t const step = 4;
   uint32_t pos = 0;
   auto const address_int_to_rule = [&](uint32_t ipv6_int) {
-    return to_string(base + step * (pos++)) + "=0x" +
+    return to_string(base + (step * (pos++))) + "=0x" +
            uint32_t_to_eight_hex_chars(ipv6_int);
   };
   std::vector<uint32_t> const ipv6_address{

--- a/src/sleep-proxy/socket.cpp
+++ b/src/sleep-proxy/socket.cpp
@@ -26,13 +26,8 @@
 
 namespace {
 ifreq get_ifreq(const std::string &iface) {
-  struct ifreq ifr {
-    {{0}}, {
-      {
-        0, { 0 }
-      }
-    }
-  };
+  struct ifreq ifr{.ifr_ifrn = {{0}},
+                   .ifr_ifru = {{.sa_family = 0, .sa_data = {0}}}};
   // NOLINTNEXTLINE
   std::copy(std::begin(iface), std::end(iface), std::begin(ifr.ifr_name));
   return ifr;

--- a/src/sleep-proxy/to_string.cpp
+++ b/src/sleep-proxy/to_string.cpp
@@ -19,7 +19,6 @@
 #include <cerrno>
 #include <cstring>
 #include <stdexcept>
-#include <vector>
 
 std::string to_string(char const *const t) { return t; }
 

--- a/src/sleep-proxy/to_string.cpp
+++ b/src/sleep-proxy/to_string.cpp
@@ -15,6 +15,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "to_string.h"
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
 #include <stdexcept>
@@ -24,7 +25,7 @@ std::string to_string(char const *const t) { return t; }
 
 bool contains_only_valid_characters(const std::string &input,
                                     const std::string &valid_chars) {
-  const bool b = std::all_of(std::begin(input), std::end(input), [&](char ch) {
+  const bool b = std::ranges::all_of(input, [&](char ch) {
     return valid_chars.find(ch) != std::string::npos;
   });
   return b;

--- a/src/sleep-proxy/wol.cpp
+++ b/src/sleep-proxy/wol.cpp
@@ -17,7 +17,6 @@
 #include "wol.h"
 #include "container_utils.h"
 #include "ethernet.h"
-#include "int_utils.h"
 #include "log.h"
 #include "socket.h"
 #include <arpa/inet.h>

--- a/src/sleep-proxy/wol_watcher.cpp
+++ b/src/sleep-proxy/wol_watcher.cpp
@@ -15,7 +15,6 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "wol_watcher.h"
-#include "ethernet.h"
 #include "log.h"
 #include "wol.h"
 #include <iterator>

--- a/src/sniffer.cpp
+++ b/src/sniffer.cpp
@@ -15,7 +15,6 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "error_suppression.h"
-#include "ethernet.h"
 #include "log.h"
 #include "packet_parser.h"
 #include "pcap_wrapper.h"

--- a/src/watchHost.cpp
+++ b/src/watchHost.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
     for (auto const &hargs : argss.host_args) {
       threads.emplace_back(thread_main, hargs);
     }
-    std::for_each(std::begin(threads), std::end(threads), [](std::thread &t) {
+    std::ranges::for_each(threads, [](std::thread &t) {
       if (t.joinable()) {
         t.join();
       }

--- a/tests/args_test.cpp
+++ b/tests/args_test.cpp
@@ -19,7 +19,6 @@
 #include "error_suppression.h"
 #include "ethernet.h"
 #include "ip_address.h"
-#include "ip_utils.h"
 #include "packet_test_utils.h"
 #include "to_string.h"
 

--- a/tests/args_test.cpp
+++ b/tests/args_test.cpp
@@ -72,7 +72,7 @@ parse_ports(std::vector<std::string> const &ports) {
 [[nodiscard]] Args get_args_vec(bool const use_syslog) {
   std::vector<std::string> params{"args_test"};
   if (use_syslog) {
-    std::cout << "syslog" << '\n';
+    std::cout << "syslog" << std::endl;
     params.emplace_back("--syslog");
   }
   return get_args(params);

--- a/tests/duplicate_address_watcher_test.cpp
+++ b/tests/duplicate_address_watcher_test.cpp
@@ -217,13 +217,12 @@ public:
     }
     Iface_Ips not_present_ips = cartesian_product(ifaces, ips);
 
-    auto const new_end = std::remove_if(
-        std::begin(not_present_ips), std::end(not_present_ips),
-        [&](Iface_Ips::value_type const &iface_ip) {
+    auto const new_end = std::ranges::remove_if(
+        not_present_ips, [&](Iface_Ips::value_type const &iface_ip) {
           return std::end(iface_ips) != std::ranges::find(iface_ips, iface_ip);
         });
     not_present_ips.resize(static_cast<std::size_t>(
-        std::distance(std::begin(not_present_ips), new_end)));
+        std::distance(std::begin(not_present_ips), std::end(new_end))));
 
     std::cout << "not_present_ips.size() == " << not_present_ips.size()
               << std::endl;

--- a/tests/duplicate_address_watcher_test.cpp
+++ b/tests/duplicate_address_watcher_test.cpp
@@ -217,13 +217,11 @@ public:
     }
     Iface_Ips not_present_ips = cartesian_product(ifaces, ips);
 
-    auto const new_end =
-        std::remove_if(std::begin(not_present_ips), std::end(not_present_ips),
-                       [&](Iface_Ips::value_type const &iface_ip) {
-                         return std::end(iface_ips) !=
-                                std::find(std::begin(iface_ips),
-                                          std::end(iface_ips), iface_ip);
-                       });
+    auto const new_end = std::remove_if(
+        std::begin(not_present_ips), std::end(not_present_ips),
+        [&](Iface_Ips::value_type const &iface_ip) {
+          return std::end(iface_ips) != std::ranges::find(iface_ips, iface_ip);
+        });
     not_present_ips.resize(static_cast<std::size_t>(
         std::distance(std::begin(not_present_ips), new_end)));
 

--- a/tests/duplicate_address_watcher_test.cpp
+++ b/tests/duplicate_address_watcher_test.cpp
@@ -38,7 +38,7 @@ struct Is_ip_occupied_dummy {
     auto const matches = [&](std::tuple<std::string, IP_address> const &item) {
       return std::make_tuple(iface, ip) == item;
     };
-    return std::any_of(std::begin(occupied), std::end(occupied), matches);
+    return std::ranges::any_of(occupied, matches);
   }
 };
 
@@ -200,7 +200,7 @@ public:
     std::vector<std::string> const ip_neigh_content = get_ip_neigh_output();
     Iface_Ips const iface_ips = get_iface_ips(ip_neigh_content);
 
-    std::cout << "iface_ips.size() = " << iface_ips.size() << std::endl;
+    std::cout << "iface_ips.size() = " << iface_ips.size() << '\n';
 
     // check for ips which are currently present
     for (auto const &iface_ip : iface_ips) {
@@ -231,8 +231,7 @@ public:
     not_present_ips.resize(static_cast<std::size_t>(
         std::distance(std::begin(not_present_ips), new_end)));
 
-    std::cout << "not_present_ips.size() == " << not_present_ips.size()
-              << std::endl;
+    std::cout << "not_present_ips.size() == " << not_present_ips.size() << '\n';
 
     for (auto const &iface_ip : not_present_ips) {
       std::string tmp_mac;

--- a/tests/duplicate_address_watcher_test.cpp
+++ b/tests/duplicate_address_watcher_test.cpp
@@ -200,7 +200,7 @@ public:
     std::vector<std::string> const ip_neigh_content = get_ip_neigh_output();
     Iface_Ips const iface_ips = get_iface_ips(ip_neigh_content);
 
-    std::cout << "iface_ips.size() = " << iface_ips.size() << '\n';
+    std::cout << "iface_ips.size() = " << iface_ips.size() << std::endl;
 
     // check for ips which are currently present
     for (auto const &iface_ip : iface_ips) {
@@ -231,7 +231,8 @@ public:
     not_present_ips.resize(static_cast<std::size_t>(
         std::distance(std::begin(not_present_ips), new_end)));
 
-    std::cout << "not_present_ips.size() == " << not_present_ips.size() << '\n';
+    std::cout << "not_present_ips.size() == " << not_present_ips.size()
+              << std::endl;
 
     for (auto const &iface_ip : not_present_ips) {
       std::string tmp_mac;

--- a/tests/duplicate_address_watcher_test.cpp
+++ b/tests/duplicate_address_watcher_test.cpp
@@ -217,12 +217,11 @@ public:
     }
     Iface_Ips not_present_ips = cartesian_product(ifaces, ips);
 
-    auto const new_end = std::ranges::remove_if(
+    auto const [erase_begin, erase_end] = std::ranges::remove_if(
         not_present_ips, [&](Iface_Ips::value_type const &iface_ip) {
           return std::end(iface_ips) != std::ranges::find(iface_ips, iface_ip);
         });
-    not_present_ips.resize(static_cast<std::size_t>(
-        std::distance(std::begin(not_present_ips), std::end(new_end))));
+    not_present_ips.erase(erase_begin, erase_end);
 
     std::cout << "not_present_ips.size() == " << not_present_ips.size()
               << std::endl;

--- a/tests/duplicate_address_watcher_test.cpp
+++ b/tests/duplicate_address_watcher_test.cpp
@@ -16,11 +16,7 @@
 
 #include "duplicate_address_watcher.h"
 
-#include "container_utils.h"
-#include "file_descriptor.h"
 #include "packet_test_utils.h"
-#include "spawn_process.h"
-#include "to_string.h"
 
 #include <algorithm>
 #include <atomic>

--- a/tests/file_descriptor_test.cpp
+++ b/tests/file_descriptor_test.cpp
@@ -27,8 +27,8 @@
 #include <string>
 #include <unistd.h>
 
-static auto const invalid_fd = int{-1};
-static auto const really_invalid_fd = int{-10};
+static int const invalid_fd = -1;
+static int const really_invalid_fd = -10;
 
 class File_descriptor_test : public CppUnit::TestFixture {
   std::string const filename = "fdclosetestfile";
@@ -152,7 +152,7 @@ public:
       Tmp_fd_remap const fd_remap{std::get<1>(self_pipes),
                                   get_fd_from_stream(stdout)};
       printf("blabla");
-      std::cout << "rumsbums" << std::endl;
+      std::cout << "rumsbums" << '\n';
     }
     auto lines = std::get<0>(self_pipes).read();
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), lines.size());

--- a/tests/file_descriptor_test.cpp
+++ b/tests/file_descriptor_test.cpp
@@ -151,7 +151,10 @@ public:
     {
       Tmp_fd_remap const fd_remap{std::get<1>(self_pipes),
                                   get_fd_from_stream(stdout)};
-      printf("blabla");
+      // purpose of test is to check that both printf and std::cout use the
+      // remapped file descriptor
+      // NOLINTNEXTLINE(modernize-use-std-print)
+      std::printf("blabla");
       std::cout << "rumsbums" << std::endl;
     }
     auto lines = std::get<0>(self_pipes).read();

--- a/tests/file_descriptor_test.cpp
+++ b/tests/file_descriptor_test.cpp
@@ -152,7 +152,7 @@ public:
       Tmp_fd_remap const fd_remap{std::get<1>(self_pipes),
                                   get_fd_from_stream(stdout)};
       printf("blabla");
-      std::cout << "rumsbums" << '\n';
+      std::cout << "rumsbums" << std::endl;
     }
     auto lines = std::get<0>(self_pipes).read();
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), lines.size());

--- a/tests/log_test.cpp
+++ b/tests/log_test.cpp
@@ -35,7 +35,7 @@ public:
   }
   static void test_log_fmt() {
     static auto const i = uint8_t{42};
-    static auto const f = double{3.14};
+    static auto const f = 3.14;
     syslog(LOG_DEBUG, "bla %d, %f", i, f);
     log(LOG_DEBUG, "bla %d, %f", i, f);
     log(LOG_NOTICE, "bla %d, %f", i, f);

--- a/tests/packet_test_utils/include/packet_test_utils.h
+++ b/tests/packet_test_utils/include/packet_test_utils.h
@@ -31,7 +31,7 @@
 
 std::vector<uint8_t> to_binary(const std::string &hex);
 
-enum class Payload_protocol {
+enum class Payload_protocol : std::uint16_t {
   ipv4 = ETHERTYPE_IP,
   ipv6 = ETHERTYPE_IPV6,
   vlan = ETHERTYPE_VLAN
@@ -73,16 +73,16 @@ cartesian_product(Container0 const &c0, Container1 const &c1) {
 }
 
 template <typename Iterator, typename End_iter>
-void check_range(Iterator &&iter, End_iter &&end, const unsigned char start,
+void check_range(Iterator &iter, End_iter const &end, const unsigned char start,
                  const unsigned char end_pos) {
   for (unsigned char c = start; c < end_pos && iter != end; c++, iter++) {
-    CPPUNIT_ASSERT_EQUAL(static_cast<uint8_t>(16 * c + c), *iter);
+    CPPUNIT_ASSERT_EQUAL(static_cast<uint8_t>((16 * c) + c), *iter);
   }
 }
 
 template <typename Iterator, typename End_iter>
-void check_header(Iterator &&iter, End_iter &&end, const unsigned char start,
-                  const unsigned char end_pos) {
+void check_header(Iterator &iter, End_iter const &end,
+                  const unsigned char start, const unsigned char end_pos) {
   check_range(iter, end, start, end_pos);
   CPPUNIT_ASSERT(iter != end);
 }

--- a/tests/packet_test_utils/packet_test_utils.cpp
+++ b/tests/packet_test_utils/packet_test_utils.cpp
@@ -16,6 +16,7 @@
 
 #include <packet_test_utils.h>
 
+#include <algorithm>
 #include <container_utils.h>
 #include <cppunit/CompilerOutputter.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -117,12 +118,12 @@ Iface_Ips get_iface_ips(std::vector<std::string> const &ip_neigh_content) {
   };
 
   std::vector<std::string> not_stale_lines;
-  std::copy_if(std::begin(ip_neigh_content), std::end(ip_neigh_content),
-               std::back_inserter(not_stale_lines), is_ip_not_stale);
+  std::ranges::copy_if(ip_neigh_content, std::back_inserter(not_stale_lines),
+                       is_ip_not_stale);
 
   Iface_Ips iface_ip(not_stale_lines.size());
-  std::transform(std::begin(not_stale_lines), std::end(not_stale_lines),
-                 std::begin(iface_ip), create_iface_ip);
+  std::ranges::transform(not_stale_lines, std::begin(iface_ip),
+                         create_iface_ip);
 
   return iface_ip;
 }
@@ -158,7 +159,7 @@ Fd_restore::~Fd_restore() {
     duplicate_file_descriptors(m_backup_fd, m_fd);
   } catch (std::exception const &e) {
     std::cout << "Fd_restore::~Fd_restore() caught exception: " << e.what()
-              << std::endl;
+              << '\n';
   }
 }
 

--- a/tests/packet_test_utils/packet_test_utils.cpp
+++ b/tests/packet_test_utils/packet_test_utils.cpp
@@ -159,7 +159,7 @@ Fd_restore::~Fd_restore() {
     duplicate_file_descriptors(m_backup_fd, m_fd);
   } catch (std::exception const &e) {
     std::cout << "Fd_restore::~Fd_restore() caught exception: " << e.what()
-              << '\n';
+              << std::endl;
   }
 }
 

--- a/tests/scope_guard_test.cpp
+++ b/tests/scope_guard_test.cpp
@@ -14,9 +14,9 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#include "file_descriptor.h"
 #include "scope_guard.h"
 
-#include "spawn_process.h"
 #include "to_string.h"
 
 #include <cppunit/extensions/HelperMacros.h>

--- a/tests/scope_guard_test.cpp
+++ b/tests/scope_guard_test.cpp
@@ -151,14 +151,14 @@ public:
   static void test_temp_ip() {
     IP_address ip = parse_ip("10.0.0.1/16");
     std::string iface{"eth0"};
-    Temp_ip ti{iface, ip};
+    Temp_ip ti{.iface = iface, .ip = ip};
     CPPUNIT_ASSERT_EQUAL("ip addr add " + ip.with_subnet() + " dev " + iface,
                          ti(Action::add));
     CPPUNIT_ASSERT_EQUAL("ip addr del " + ip.with_subnet() + " dev " + iface,
                          ti(Action::del));
 
     iface = "even more randomness";
-    Temp_ip ti2{iface, ip};
+    Temp_ip ti2{.iface = iface, .ip = ip};
     CPPUNIT_ASSERT_EQUAL("ip addr add " + ip.with_subnet() + " dev " + iface,
                          ti2(Action::add));
     CPPUNIT_ASSERT_EQUAL("ip addr del " + ip.with_subnet() + " dev " + iface,
@@ -168,7 +168,7 @@ public:
   static void test_drop_port() {
     IP_address ip = parse_ip("10.0.0.1/16");
     static const uint16_t port0{1234};
-    Drop_port op{ip, port0};
+    Drop_port op{.ip = ip, .port = port0};
     CPPUNIT_ASSERT_EQUAL(
         "iptables -w -I INPUT -d " + ip.pure() + " -p tcp --syn --dport " +
             std::to_string(static_cast<uint32_t>(port0)) + " -j DROP",
@@ -180,7 +180,7 @@ public:
 
     ip = parse_ip("fe80::affe");
     static const uint16_t port1 = 666;
-    Drop_port op2{ip, port1};
+    Drop_port op2{.ip = ip, .port = port1};
     CPPUNIT_ASSERT_EQUAL(
         "ip6tables -w -I INPUT -d " + ip.pure() + " -p tcp --syn --dport " +
             std::to_string(static_cast<uint32_t>(port1)) + " -j DROP",
@@ -194,7 +194,7 @@ public:
   static void test_reject_tp() {
     IP_address ip = parse_ip("10.0.0.1/16");
 
-    Reject_tp rt{ip, Reject_tp::TP::UDP};
+    Reject_tp rt{.ip = ip, .tcp_udp = Reject_tp::TP::UDP};
     CPPUNIT_ASSERT_EQUAL("iptables -w -I INPUT -d " + ip.pure() +
                              " -p udp -j REJECT",
                          rt(Action::add));
@@ -203,7 +203,7 @@ public:
                          rt(Action::del));
 
     ip = parse_ip("10.0.0.1/16");
-    Reject_tp rt2{ip, Reject_tp::TP::TCP};
+    Reject_tp rt2{.ip = ip, .tcp_udp = Reject_tp::TP::TCP};
     CPPUNIT_ASSERT_EQUAL("iptables -w -I INPUT -d " + ip.pure() +
                              " -p tcp -j REJECT",
                          rt2(Action::add));
@@ -212,7 +212,7 @@ public:
                          rt2(Action::del));
 
     ip = parse_ip("2001::dead:affe/16");
-    Reject_tp rt3{ip, Reject_tp::TP::TCP};
+    Reject_tp rt3{.ip = ip, .tcp_udp = Reject_tp::TP::TCP};
     CPPUNIT_ASSERT_EQUAL("ip6tables -w -I INPUT -d " + ip.pure() +
                              " -p tcp -j REJECT",
                          rt3(Action::add));

--- a/tests/scope_guard_test.cpp
+++ b/tests/scope_guard_test.cpp
@@ -139,6 +139,8 @@ public:
     CPPUNIT_ASSERT_EQUAL(ints, guard.cont);
     CPPUNIT_ASSERT_EQUAL(x, guard.ref);
 
+    // using out of range value is the point of the test
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     CPPUNIT_ASSERT_EQUAL(std::string(), guard(static_cast<Action>(3)));
 
     CPPUNIT_ASSERT_EQUAL(&ints_mutex, &guard.cont_mutex);

--- a/tests/socket_test.cpp
+++ b/tests/socket_test.cpp
@@ -32,7 +32,7 @@ struct Socket_listen : public Socket {
   Socket_listen(int domain, int type, int protocol = 0)
       : Socket(domain, type, protocol) {}
 
-  template <typename Sockaddr> void bind(Sockaddr &&sockaddr) {
+  template <typename Sockaddr> void bind(Sockaddr const &sockaddr) {
     const int ret_val =
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         ::bind(fd(), reinterpret_cast<const struct sockaddr *>(&sockaddr),

--- a/tests/socket_test.cpp
+++ b/tests/socket_test.cpp
@@ -91,14 +91,16 @@ public:
   static void test_ioctl_throws() {
     Socket s0(AF_INET, SOCK_DGRAM);
 
-    struct ifreq ifreq{{{0}}, {{0, {0}}}};
+    struct ifreq ifreq{.ifr_ifrn = {{0}},
+                       .ifr_ifru = {{.sa_family = 0, .sa_data = {0}}}};
 
     CPPUNIT_ASSERT_THROW(s0.ioctl(0, ifreq), std::runtime_error);
   }
 
   static void test_send_to() {
     static auto const leet_port = uint16_t{31337};
-    sockaddr_in addr{0, 0, {0}, {0}};
+    sockaddr_in addr{
+        .sin_family = 0, .sin_port = 0, .sin_addr = {0}, .sin_zero = {0}};
     addr.sin_family = AF_INET;
     addr.sin_port = leet_port;
 
@@ -129,7 +131,10 @@ public:
     s1.send_to(data, 0, addr);
     CPPUNIT_ASSERT(data == s0.recv());
 
-    sockaddr_in const broken_addr{0xff, 0xff, {0xff}, {0xff}};
+    sockaddr_in const broken_addr{.sin_family = 0xff,
+                                  .sin_port = 0xff,
+                                  .sin_addr = {0xff},
+                                  .sin_zero = {0xff}};
     CPPUNIT_ASSERT_THROW(s1.send_to(data, 0, broken_addr), std::runtime_error);
   }
 

--- a/tests/to_string_test.cpp
+++ b/tests/to_string_test.cpp
@@ -16,9 +16,6 @@
 
 #include "to_string.h"
 
-#include "packet_test_utils.h"
-#include "spawn_process.h"
-
 #include <cppunit/extensions/HelperMacros.h>
 #include <string>
 

--- a/tests/wol_test.cpp
+++ b/tests/wol_test.cpp
@@ -84,6 +84,8 @@ public:
 
   static void test_ostream_operator_with_invalid_wol_method() {
     std::stringstream stream;
+    // using out of bounds value is the point of the test
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     auto invalid_method = static_cast<Wol_method>(-1);
     CPPUNIT_ASSERT_THROW(stream << invalid_method, std::runtime_error);
   }

--- a/tests/wol_watcher_test.cpp
+++ b/tests/wol_watcher_test.cpp
@@ -37,9 +37,9 @@ std::vector<uint8_t> gen_random_data(size_t const size) {
 }
 
 pcap_pkthdr create_header(size_t packet_length) {
-  const struct pcap_pkthdr header {
-    {0, 0}, 0, static_cast<uint32_t>(packet_length)
-  };
+  const struct pcap_pkthdr header{.ts = {.tv_sec = 0, .tv_usec = 0},
+                                  .caplen = 0,
+                                  .len = static_cast<uint32_t>(packet_length)};
   return header;
 }
 } // namespace


### PR DESCRIPTION
The code is mostly used as an example how I would at minimum maintain a C++ project and what tools and checks I use. Therefore the code should be modernised sometimes.

Due to the lack of a nightly and the linter action only checking changed files, a few findings have been accumulated since the switch to C++23 and LLVM 19.